### PR TITLE
feat: introduce --lib-name on static-glue to skip `cargo metadata` call

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -157,10 +157,15 @@ USAGE:
     cargo-php static-glue [OPTIONS]
 
 OPTIONS:
-        --ext-name <EXT_NAME>
+        --lib-name <LIB_NAME>
             Name used for the php-src extension. Defaults to the library target name with dashes
-            replaced by underscores. Must be a valid C identifier. Only affects file and configure
-            naming; the Rust symbols always come from the library target name
+            replaced by underscores. Must be a valid library name
+
+        --ext-name <EXT_NAME>
+            Name used for the target library. Defaults to `<lib-name>` if provided, or the library
+            target name with dashes replaced by underscores. Must be a valid C identifier. Only
+            affects file and configure naming; the Rust symbols always come from the library target
+            name
 
         --force
             Overwrite existing files in the output directory

--- a/crates/cli/src/static_glue.rs
+++ b/crates/cli/src/static_glue.rs
@@ -25,13 +25,19 @@ pub struct StaticGlue {
     /// in the directory the command is called.
     #[arg(long)]
     manifest: Option<PathBuf>,
+    /// Name used for the target library. Defaults to the library target name
+    /// with dashes replaced by underscores. Must be a valid library name. Only
+    /// affects the Rust symbols. Only use to skip `cargo metadata` call.
+    #[arg(long)]
+    lib_name: Option<String>,
     /// Directory to write the glue files to. Defaults to `./<ext-name>/`.
     #[arg(short, long)]
     out: Option<PathBuf>,
-    /// Name used for the php-src extension. Defaults to the library target
-    /// name with dashes replaced by underscores. Must be a valid C identifier.
-    /// Only affects file and configure naming; the Rust symbols always come
-    /// from the library target name.
+    /// Name used for the php-src extension. Defaults to `<lib-name>` if
+    /// provided, or the library target name with dashes replaced by
+    /// underscores. Must be a valid C identifier. Only affects file and
+    /// configure naming; the Rust symbols always come from the library target
+    /// name.
     #[arg(long)]
     ext_name: Option<String>,
     /// Overwrite existing files in the output directory.
@@ -41,7 +47,11 @@ pub struct StaticGlue {
 
 impl StaticGlue {
     pub fn handle(self) -> AResult<()> {
-        let lib_name = find_staticlib_target(self.manifest.as_deref())?.replace('-', "_");
+        let lib_name = self
+            .lib_name
+            .map_or_else(|| find_staticlib_target(self.manifest.as_deref()), Ok)?
+            .replace('-', "_");
+        validate_ext_name(&lib_name)?;
         let ext_name = self.ext_name.unwrap_or_else(|| lib_name.clone());
         validate_ext_name(&ext_name)?;
 

--- a/guide/src/advanced/static_linking.md
+++ b/guide/src/advanced/static_linking.md
@@ -77,8 +77,8 @@ This writes a directory named after your extension containing:
 
 The extension name defaults to the library target name with dashes replaced
 by underscores; override it with `--ext-name`. The override only affects file
-and configure naming; the Rust symbols always come from the library target
-name.
+and configure naming; the Rust symbols come from the library target name;
+override it with `--lib-name` if `cargo metadata` is not available.
 
 ## The two-pass build
 


### PR DESCRIPTION
## Description

Follow-up on #764, which made the library name always derives from library target name through `cargo metadata`, reintroduce a new flag to skip `cargo metadata` call.

As I'm integrating `ext-php-rs` in a Bazel build, depending on `cargo metadata` is a huge burden: the metadata call refetches the entire dependencies of the crate, because it's ran in isolation. Being able to inject the library name by myself (which I know) makes it lighter. I reckon it's an advanced use case, but I think the entire static-glue already is.

cc @TobiasBengtsson @ptondereau 

## Checklist

<!--
Check the boxes that apply (put an `x` in the brackets, like `[x]`). You can also check boxes after the PR is created.
-->

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [ ] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.

<!-- :heart: Thank you for your contribution! -->
