### PR TITLE
build: add asan dev shell and CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,6 +313,85 @@ jobs:
           nm -D --defined-only target/release/examples/libhello_world.so | grep -q ' T hello_world_get_module$'
           ! nm -D --defined-only target/release/examples/libhello_world.so | grep -q ' T get_module$'
 
+  test-asan:
+    name: Test with ASan
+    runs-on: ubuntu-latest
+    env:
+      clang: "17"
+      php_version: "8.5"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.php_version }}
+        env:
+          debug: true
+
+      - name: Install libphp-embed
+        # The GitHub runner image no longer ships the ondrej PPA, and setup-php
+        # uses its cached PHP build. Add the PPA and its "main/debug" component
+        # (where libphp*-embed-dbgsym lives) so the embed library resolves.
+        run: |
+          sudo add-apt-repository -y ppa:ondrej/php
+          src=$(grep -rlE 'ondrej' /etc/apt/sources.list.d/ | head -n1)
+          if [ -n "$src" ] && ! grep -q 'main/debug' "$src"; then
+            if [ "${src##*.}" = "sources" ]; then
+              sudo sed -i -E '/^Components:/ s#$# main/debug#' "$src"
+            else
+              sudo sed -i -E 's#(^deb .* )main([[:space:]]*$)#\1main main/debug\2#' "$src"
+            fi
+          fi
+          sudo apt-get update -y
+          sudo apt-get install -y libphp${{ env.php_version }}-embed-dbgsym
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rust-src
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ env.RUST_CACHE_PREFIX }}
+
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/llvm-${{ env.clang }}
+          key: ubuntu-latest-llvm-${{ env.clang }}
+
+      - name: Setup LLVM & Clang
+        id: clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: ${{ env.clang }}
+          directory: ${{ runner.temp }}/llvm-${{ env.clang }}
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+
+      - name: Configure Clang
+        run: |
+          echo "LIBCLANG_PATH=${{ runner.temp }}/llvm-${{ env.clang }}/lib" >> $GITHUB_ENV
+          echo "LLVM_VERSION=${{ steps.clang.outputs.version }}" >> $GITHUB_ENV
+          echo "LLVM_CONFIG_PATH=${{ runner.temp }}/llvm-${{ env.clang }}/bin/llvm-config" >> $GITHUB_ENV
+
+      - name: Test with ASan
+        # libphp here is not ASan-instrumented (the nix .#asan shell is the
+        # fully instrumented setup); the executable's ASan runtime still
+        # intercepts every allocation once USE_ZEND_ALLOC routes ZendMM
+        # through malloc. Doctests cannot build with -Zbuild-std, hence --lib.
+        env:
+          RUSTFLAGS: "-Zsanitizer=address -Clink-arg=-Wl,-undefined,dynamic_lookup"
+          USE_ZEND_ALLOC: "0"
+          USE_TRACKED_ALLOC: "1"
+          ASAN_SYMBOLIZER_PATH: ${{ runner.temp }}/llvm-${{ env.clang }}/bin/llvm-symbolizer
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan-suppressions.txt
+        run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu -p ext-php-rs --lib --features embed,closure,anyhow,observer
+
   build-musl:
     name: musl / ${{ matrix.php }} / ${{ matrix.phpts[1] }}
     runs-on: ubuntu-latest

--- a/.lsan-suppressions.txt
+++ b/.lsan-suppressions.txt
@@ -1,0 +1,14 @@
+# PHP leaks persistent allocations at embed shutdown by design; php-src's own
+# run-tests gave up on detect_leaks there (run-tests.php:2685).
+leak:libphp
+# Pre-existing library leaks, tracked in
+# docs/plans/2026-07-31-v0.16-breaking-backlog.md (into_raw constructors and
+# bailout-skipped destructors). Remove each entry when its fix lands.
+leak:SapiBuilder
+leak:PhpException>::throw
+leak:ext_php_rs::exception::throw
+leak:as_arg_info
+# Intentional: these tests trigger a PHP bailout on purpose, so their own
+# locals are never dropped.
+leak:test_memory_leak
+leak:exception::tests::test_throw

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,24 @@
       php-zts-debug =
         (withDebug (pkgs.php.override { ztsSupport = true; })).buildEnv { embedSupport = true; };
       php-zts-debug-dev = php-zts-debug.unwrapped.dev;
+      withAsan = phpPkg: phpPkg.override {
+        stdenv = pkgs.clangStdenv;
+        valgrindSupport = false;
+        phpAttrsOverrides = final: prev: {
+          configureFlags = prev.configureFlags ++ [
+            "--enable-debug"
+            "--enable-address-sanitizer"
+          ];
+        };
+      };
+      php-asan = (withAsan pkgs.php).buildEnv {
+        extensions = _: [ ];
+        embedSupport = true;
+      };
+      php-asan-dev = php-asan.unwrapped.dev;
+      rust-nightly = pkgs.rust-bin.nightly.latest.default.override {
+        extensions = [ "rust-src" ];
+      };
       # mago is not packaged in nixpkgs; pin the upstream static musl binary so
       # local dev and CI (nhedger/setup-mago) run the exact same version.
       mago = pkgs.stdenvNoCC.mkDerivation rec {
@@ -66,6 +84,27 @@
           export BINDGEN_EXTRA_CLANG_ARGS="-resource-dir ${pkgs.libclang.lib}/lib/clang/${pkgs.lib.versions.major (pkgs.lib.getVersion pkgs.clang)} -isystem ${pkgs.glibc.dev}/include"
         '';
       };
+      asanShell = pkgs.mkShell {
+        buildInputs = [
+          php-asan
+          php-asan-dev
+          pkgs.libclang.lib
+          pkgs.clang
+          pkgs.llvmPackages.llvm
+        ];
+
+        nativeBuildInputs = [ rust-nightly ];
+
+        shellHook = ''
+          export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
+          export BINDGEN_EXTRA_CLANG_ARGS="-resource-dir ${pkgs.libclang.lib}/lib/clang/${pkgs.lib.versions.major (pkgs.lib.getVersion pkgs.clang)} -isystem ${pkgs.glibc.dev}/include"
+          export RUSTFLAGS="-Zsanitizer=address -Clink-arg=-Wl,-undefined,dynamic_lookup"
+          export USE_ZEND_ALLOC=0
+          export USE_TRACKED_ALLOC=1
+          export ASAN_SYMBOLIZER_PATH="${pkgs.llvmPackages.llvm}/bin/llvm-symbolizer"
+          export LSAN_OPTIONS="suppressions=$PWD/.lsan-suppressions.txt"
+        '';
+      };
     in
     {
       devShells.${system} = {
@@ -73,6 +112,7 @@
         zts = mkShellFor php-zts php-zts-dev;
         debug = mkShellFor php-debug php-debug-dev;
         zts-debug = mkShellFor php-zts-debug php-zts-debug-dev;
+        asan = asanShell;
       };
     };
 }


### PR DESCRIPTION
## Description

Adds ASan/LSan tooling on two levels:

- `nix develop .#asan`: PHP built with clang, `--enable-debug` and `--enable-address-sanitizer` (fully instrumented libphp), nightly rustc with `rust-src`, and the env wiring (`RUSTFLAGS`, `USE_ZEND_ALLOC=0`, `USE_TRACKED_ALLOC=1`, LSan suppressions).
- `test-asan` CI job: same run against the setup-php libphp-embed. That libphp is not instrumented, but the executable's ASan runtime still intercepts every allocation once `USE_ZEND_ALLOC=0` routes ZendMM through malloc; the nix shell stays the fully instrumented setup.

```
cargo test -Zbuild-std --target x86_64-unknown-linux-gnu -p ext-php-rs --lib --features embed,closure,anyhow,observer
```

Scope is the lib tests with `embed`: the `tests/` cdylib package is out of scope since a plain `php` binary cannot dlopen an instrumented cdylib. `--lib` skips doctests, which cargo cannot build with `-Zbuild-std`.

`.lsan-suppressions.txt` suppresses PHP's by-design persistent allocations at embed shutdown, three pre-existing library leaks now confirmed by LSan (`SapiBuilder::build` and `PhpException::throw`/`exception::throw` `CString`s, `Arg::as_arg_info`), and tests that trigger bailouts on purpose. Each entry is removed when its fix lands.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [ ] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
