### PR TITLE
fix(zend)!: return Option from engine-input accessors

### DIFF
--- a/guide/src/migration-guides/v0.16.md
+++ b/guide/src/migration-guides/v0.16.md
@@ -285,3 +285,48 @@ fn rescale(ht: &mut ZendHashTable) {
 PHP-facing signature does not change. If you cannot obtain a mutable borrow at
 the outermost frame, the array is genuinely shared and mutating it was unsound
 before this release.
+
+## Engine-Input Accessors Return `Option` Instead of Panicking
+
+Accessors that read data controlled by the engine or the request used to
+`panic!`, which aborts the process inside an `extern "C"` frame. They now
+return `Option` and align with `http_server_vars`, which already did.
+
+Affected signatures:
+
+| Before (v0.15) | After (v0.16) |
+|---|---|
+| `ProcessGlobals::http_get_vars() -> &ZendHashTable` | `-> Option<&ZendHashTable>` |
+| `ProcessGlobals::http_post_vars() -> &ZendHashTable` | `-> Option<&ZendHashTable>` |
+| `ProcessGlobals::http_cookie_vars() -> &ZendHashTable` | `-> Option<&ZendHashTable>` |
+| `ProcessGlobals::http_env_vars() -> &ZendHashTable` | `-> Option<&ZendHashTable>` |
+| `ProcessGlobals::http_files_vars() -> &ZendHashTable` | `-> Option<&ZendHashTable>` |
+| `ProcessGlobals::http_request_vars() -> Option<&ZendHashTable>` | `-> Result<Option<&ZendHashTable>>` |
+| `SapiHeader::as_str() -> &str` | `-> Option<&str>` |
+| `SapiHeader::name() -> &str` | `-> Option<&str>` |
+| `zend::php_sapi_name() -> String` | `-> Option<String>` |
+
+`http_request_vars` distinguishes engine failures from absence: `Err` carries
+`Error::AutoGlobalLoadFailed("_REQUEST")` or `Error::ZvalConversion` where it
+previously panicked, and `Ok(None)` means the global is not populated.
+`SapiHeader::value` keeps its `Option` signature but returns `None` where it
+previously panicked (non-UTF-8 header).
+
+### Before (v0.15)
+
+```rust,ignore
+let get = ProcessGlobals::get().http_get_vars().to_owned();
+let name = header.name();
+```
+
+### After (v0.16)
+
+```rust,ignore
+let get = ProcessGlobals::get().http_get_vars()?.to_owned();
+let name = header.name()?;
+```
+
+`None` means the global has not been populated as an array (yet) or, for
+headers, that the bytes are not valid UTF-8. In a regular request context the
+superglobals are populated and unwrapping stays reasonable; before request
+startup or in exotic SAPIs it no longer aborts the process.

--- a/guide/src/superglobals.md
+++ b/guide/src/superglobals.md
@@ -23,6 +23,12 @@ The `ProcessGlobals` type provides access to the common HTTP superglobals:
 | `http_files_vars()`   | `$_FILES`      |
 | `http_request_vars()` | `$_REQUEST`    |
 
+Every accessor returns `Option<&ZendHashTable>`: `None` means the global has
+not been populated as an array (yet), for example before request startup or in
+a SAPI that does not provide it. The exception is `http_request_vars()`, which
+returns `Result<Option<&ZendHashTable>>` because building `$_REQUEST` involves
+the engine: `Err` reports an engine failure, `Ok(None)` means not populated.
+
 ### Basic Example
 
 ```rust,no_run
@@ -34,7 +40,7 @@ use ext_php_rs::zend::ProcessGlobals;
 #[php_function]
 pub fn get_cookie(name: String) -> Option<String> {
     ProcessGlobals::get()
-        .http_cookie_vars()
+        .http_cookie_vars()?
         .get(name.as_str())
         .and_then(|zval| zval.string())
 }
@@ -42,7 +48,7 @@ pub fn get_cookie(name: String) -> Option<String> {
 #[php_function]
 pub fn get_query_param(name: String) -> Option<String> {
     ProcessGlobals::get()
-        .http_get_vars()
+        .http_get_vars()?
         .get(name.as_str())
         .and_then(|zval| zval.string())
 }
@@ -50,7 +56,7 @@ pub fn get_query_param(name: String) -> Option<String> {
 #[php_function]
 pub fn get_post_param(name: String) -> Option<String> {
     ProcessGlobals::get()
-        .http_post_vars()
+        .http_post_vars()?
         .get(name.as_str())
         .and_then(|zval| zval.string())
 }
@@ -59,8 +65,8 @@ pub fn get_post_param(name: String) -> Option<String> {
 
 ### Accessing `$_SERVER`
 
-The `$_SERVER` superglobal is lazy-initialized in PHP, so `http_server_vars()`
-returns an `Option`:
+The `$_SERVER` superglobal is lazy-initialized in PHP; `http_server_vars()`
+triggers that initialization before reading it:
 
 ```rust,no_run
 # #![cfg_attr(windows, feature(abi_vectorcall))]
@@ -105,7 +111,7 @@ use ext_php_rs::zend::ProcessGlobals;
 #[php_function]
 pub fn get_uploaded_file_name(field: String) -> Option<String> {
     let globals = ProcessGlobals::get();
-    let files = globals.http_files_vars();
+    let files = globals.http_files_vars()?;
 
     // $_FILES structure: $_FILES['field']['name'], ['tmp_name'], ['size'], etc.
     files
@@ -118,7 +124,7 @@ pub fn get_uploaded_file_name(field: String) -> Option<String> {
 #[php_function]
 pub fn get_uploaded_file_tmp_path(field: String) -> Option<String> {
     let globals = ProcessGlobals::get();
-    let files = globals.http_files_vars();
+    let files = globals.http_files_vars()?;
 
     files
         .get(field.as_str())?
@@ -142,13 +148,13 @@ use ext_php_rs::types::ZendHashTable;
 use ext_php_rs::zend::ProcessGlobals;
 
 #[php_function]
-pub fn get_all_cookies() -> ZBox<ZendHashTable> {
-    ProcessGlobals::get().http_cookie_vars().to_owned()
+pub fn get_all_cookies() -> Option<ZBox<ZendHashTable>> {
+    Some(ProcessGlobals::get().http_cookie_vars()?.to_owned())
 }
 
 #[php_function]
-pub fn get_all_get_params() -> ZBox<ZendHashTable> {
-    ProcessGlobals::get().http_get_vars().to_owned()
+pub fn get_all_get_params() -> Option<ZBox<ZendHashTable>> {
+    Some(ProcessGlobals::get().http_get_vars()?.to_owned())
 }
 
 #[php_function]

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,6 +79,10 @@ pub enum Error {
     SapiWriteUnavailable,
     /// Failed to make an object lazy (PHP 8.4+)
     LazyObjectFailed,
+    /// The engine failed to load an auto-global.
+    ///
+    /// The enum carries the name of the auto-global.
+    AutoGlobalLoadFailed(&'static str),
 }
 
 impl Display for Error {
@@ -130,6 +134,9 @@ impl Display for Error {
             }
             Error::LazyObjectFailed => {
                 write!(f, "Failed to make the object lazy")
+            }
+            Error::AutoGlobalLoadFailed(name) => {
+                write!(f, "The engine failed to load the `{name}` auto-global.")
             }
         }
     }

--- a/src/zend/globals.rs
+++ b/src/zend/globals.rs
@@ -9,6 +9,7 @@ use std::str;
 use std::sync::{Arc, LazyLock};
 
 use crate::boxed::ZBox;
+use crate::error::{Error, Result};
 use crate::exception::PhpResult;
 #[cfg(php82)]
 use crate::ffi::zend_atomic_bool_store;
@@ -404,47 +405,38 @@ impl ProcessGlobals {
 
     /// Get the HTTP POST variables. Equivalent of $_POST.
     ///
-    /// # Panics
-    ///
-    /// * If the post global is not found or fails to be populated.
+    /// Returns `None` if the global has not been populated as an array (yet).
     #[must_use]
-    pub fn http_post_vars(&self) -> &ZendHashTable {
-        self.http_globals[TRACK_VARS_POST as usize]
-            .array()
-            .expect("Type is not a ZendArray")
+    pub fn http_post_vars(&self) -> Option<&ZendHashTable> {
+        self.http_globals[TRACK_VARS_POST as usize].array()
     }
 
     /// Get the HTTP GET variables. Equivalent of $_GET.
     ///
-    /// # Panics
-    ///
-    /// * If the get global is not found or fails to be populated.
+    /// Returns `None` if the global has not been populated as an array (yet).
     #[must_use]
-    pub fn http_get_vars(&self) -> &ZendHashTable {
-        self.http_globals[TRACK_VARS_GET as usize]
-            .array()
-            .expect("Type is not a ZendArray")
+    pub fn http_get_vars(&self) -> Option<&ZendHashTable> {
+        self.http_globals[TRACK_VARS_GET as usize].array()
     }
 
     /// Get the HTTP Cookie variables. Equivalent of $_COOKIE.
     ///
-    /// # Panics
-    ///
-    /// * If the cookie global is not found or fails to be populated.
+    /// Returns `None` if the global has not been populated as an array (yet).
     #[must_use]
-    pub fn http_cookie_vars(&self) -> &ZendHashTable {
-        self.http_globals[TRACK_VARS_COOKIE as usize]
-            .array()
-            .expect("Type is not a ZendArray")
+    pub fn http_cookie_vars(&self) -> Option<&ZendHashTable> {
+        self.http_globals[TRACK_VARS_COOKIE as usize].array()
     }
 
     /// Get the HTTP Request variables. Equivalent of $_REQUEST.
     ///
-    /// # Panics
+    /// Returns `Ok(None)` if the global has not been populated (yet).
     ///
-    /// * If the request global is not found or fails to be populated.
-    /// * If the request global is not a [`ZendHashTable`].
-    pub fn http_request_vars(&self) -> Option<&ZendHashTable> {
+    /// # Errors
+    ///
+    /// * [`Error::AutoGlobalLoadFailed`] - If the engine failed to load the
+    ///   `_REQUEST` auto-global.
+    /// * [`Error::ZvalConversion`] - If the global is not an array.
+    pub fn http_request_vars(&self) -> Result<Option<&ZendHashTable>> {
         cfg_if::cfg_if! {
             if #[cfg(php81)] {
                 let key = unsafe {
@@ -461,10 +453,9 @@ impl ProcessGlobals {
 
         // `$_REQUEST` is lazy-initted, we need to call `zend_is_auto_global` to make
         // sure it's populated.
-        assert!(
-            unsafe { zend_is_auto_global(key) },
-            "Failed to get request global"
-        );
+        if !unsafe { zend_is_auto_global(key) } {
+            return Err(Error::AutoGlobalLoadFailed("_REQUEST"));
+        }
 
         let symbol_table = &ExecutorGlobals::get().symbol_table;
         cfg_if::cfg_if! {
@@ -475,35 +466,30 @@ impl ProcessGlobals {
             }
         };
 
-        if request.is_null() {
-            return None;
-        }
+        let Some(request) = (unsafe { request.as_ref() }) else {
+            return Ok(None);
+        };
 
-        Some(unsafe { (*request).array() }.expect("Type is not a ZendArray"))
+        request
+            .array()
+            .map(Some)
+            .ok_or_else(|| Error::ZvalConversion(request.get_type()))
     }
 
     /// Get the HTTP Environment variables. Equivalent of $_ENV.
     ///
-    /// # Panics
-    ///
-    /// * If the environment global is not found or fails to be populated.
+    /// Returns `None` if the global has not been populated as an array (yet).
     #[must_use]
-    pub fn http_env_vars(&self) -> &ZendHashTable {
-        self.http_globals[TRACK_VARS_ENV as usize]
-            .array()
-            .expect("Type is not a ZendArray")
+    pub fn http_env_vars(&self) -> Option<&ZendHashTable> {
+        self.http_globals[TRACK_VARS_ENV as usize].array()
     }
 
     /// Get the HTTP Files variables. Equivalent of $_FILES.
     ///
-    /// # Panics
-    ///
-    /// * If the files global is not found or fails to be populated.
+    /// Returns `None` if the global has not been populated as an array (yet).
     #[must_use]
-    pub fn http_files_vars(&self) -> &ZendHashTable {
-        self.http_globals[TRACK_VARS_FILES as usize]
-            .array()
-            .expect("Type is not a ZendArray")
+    pub fn http_files_vars(&self) -> Option<&ZendHashTable> {
+        self.http_globals[TRACK_VARS_FILES as usize].array()
     }
 }
 
@@ -587,27 +573,35 @@ pub type SapiHeader = sapi_header_struct;
 impl<'a> SapiHeader {
     /// Get the header as a string.
     ///
-    /// # Panics
-    ///
-    /// * If the header is not a valid UTF-8 string.
+    /// Returns `None` if the header is null, empty or not valid UTF-8.
     #[must_use]
-    pub fn as_str(&'a self) -> &'a str {
+    pub fn as_str(&'a self) -> Option<&'a str> {
+        if self.header.is_null() || self.header_len == 0 {
+            return None;
+        }
         unsafe {
             let slice = slice::from_raw_parts(self.header as *const u8, self.header_len);
-            str::from_utf8(slice).expect("Invalid header string")
+            str::from_utf8(slice).ok()
         }
     }
 
     /// Returns the header name (key).
+    ///
+    /// Returns `None` if the header is null, empty or not valid UTF-8.
     #[must_use]
-    pub fn name(&'a self) -> &'a str {
-        self.as_str().split(':').next().unwrap_or("").trim()
+    pub fn name(&'a self) -> Option<&'a str> {
+        Some(self.as_str()?.split(':').next().unwrap_or("").trim())
     }
 
     /// Returns the header value.
+    ///
+    /// Returns `None` if the header is null, empty, not valid UTF-8 or has no
+    /// value.
     #[must_use]
     pub fn value(&'a self) -> Option<&'a str> {
-        self.as_str().split_once(':').map(|(_, value)| value.trim())
+        self.as_str()?
+            .split_once(':')
+            .map(|(_, value)| value.trim())
     }
 }
 
@@ -912,36 +906,73 @@ impl<T> DerefMut for GlobalWriteGuard<T> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::raw::c_char;
+
+    #[test]
+    fn sapi_header_parses_name_and_value() {
+        let headers = [
+            ("Content-Type: text/html", "Content-Type", "text/html"),
+            ("X: Custom:Header", "X", "Custom:Header"),
+        ];
+
+        for (header_text, name, value) in headers {
+            let header = SapiHeader {
+                header: header_text.as_bytes().as_ptr() as *mut c_char,
+                header_len: header_text.len(),
+            };
+            assert_eq!(header.name(), Some(name), "Header name mismatch");
+            assert_eq!(header.value(), Some(value), "Header value mismatch");
+            assert_eq!(
+                header.as_str(),
+                Some(format!("{name}: {value}").as_str()),
+                "Header string mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn sapi_header_with_invalid_utf8_returns_none() {
+        let bytes: &[u8] = b"X: \xFF\xFE";
+        let header = SapiHeader {
+            header: bytes.as_ptr() as *mut c_char,
+            header_len: bytes.len(),
+        };
+        assert_eq!(header.as_str(), None);
+        assert_eq!(header.name(), None);
+        assert_eq!(header.value(), None);
+    }
+
+    #[test]
+    fn sapi_header_with_null_pointer_returns_none() {
+        let header = SapiHeader {
+            header: std::ptr::null_mut(),
+            header_len: 0,
+        };
+        assert_eq!(header.as_str(), None);
+        assert_eq!(header.name(), None);
+        assert_eq!(header.value(), None);
+    }
+
+    #[test]
+    fn sapi_header_with_zero_length_returns_none() {
+        let header = SapiHeader {
+            header: c"".as_ptr().cast_mut(),
+            header_len: 0,
+        };
+        assert_eq!(header.as_str(), None);
+        assert_eq!(header.name(), None);
+        assert_eq!(header.value(), None);
+    }
+}
+
 #[cfg(feature = "embed")]
 #[cfg(test)]
 mod embed_tests {
     use super::*;
     use crate::embed::Embed;
-    use std::os::raw::c_char;
-
-    #[test]
-    fn test_sapi_header() {
-        Embed::run(|| {
-            let headers = [
-                ("Content-Type: text/html", "Content-Type", "text/html"),
-                ("X: Custom:Header", "X", "Custom:Header"),
-            ];
-
-            for (header_text, name, value) in headers {
-                let header = SapiHeader {
-                    header: header_text.as_bytes().as_ptr() as *mut c_char,
-                    header_len: header_text.len(),
-                };
-                assert_eq!(header.name(), name, "Header name mismatch");
-                assert_eq!(header.value(), Some(value), "Header value mismatch");
-                assert_eq!(
-                    header.as_str(),
-                    format!("{name}: {value}"),
-                    "Header string mismatch"
-                );
-            }
-        });
-    }
 
     #[test]
     fn test_executor_globals() {

--- a/src/zend/mod.rs
+++ b/src/zend/mod.rs
@@ -178,12 +178,12 @@ pub fn output_write(data: &[u8]) -> usize {
 
 /// Get the name of the SAPI module.
 ///
-/// # Panics
-///
-/// * If the module name is not a valid [`CStr`]
-///
-/// [`CStr`]: std::ffi::CStr
-pub fn php_sapi_name() -> String {
+/// Returns `None` if the module name is null or not valid UTF-8.
+#[must_use]
+pub fn php_sapi_name() -> Option<String> {
+    if unsafe { sapi_module.name }.is_null() {
+        return None;
+    }
     let c_str = unsafe { std::ffi::CStr::from_ptr(sapi_module.name) };
-    c_str.to_str().expect("Unable to parse CStr").to_string()
+    c_str.to_str().ok().map(ToString::to_string)
 }

--- a/tests/src/integration/globals/mod.rs
+++ b/tests/src/integration/globals/mod.rs
@@ -2,17 +2,17 @@ use ext_php_rs::{boxed::ZBox, prelude::*, types::ZendHashTable, zend::ProcessGlo
 
 #[php_function]
 pub fn test_globals_http_get() -> ZBox<ZendHashTable> {
-    ProcessGlobals::get().http_get_vars().to_owned()
+    ProcessGlobals::get().http_get_vars().unwrap().to_owned()
 }
 
 #[php_function]
 pub fn test_globals_http_post() -> ZBox<ZendHashTable> {
-    ProcessGlobals::get().http_post_vars().to_owned()
+    ProcessGlobals::get().http_post_vars().unwrap().to_owned()
 }
 
 #[php_function]
 pub fn test_globals_http_cookie() -> ZBox<ZendHashTable> {
-    ProcessGlobals::get().http_cookie_vars().to_owned()
+    ProcessGlobals::get().http_cookie_vars().unwrap().to_owned()
 }
 
 #[php_function]
@@ -25,12 +25,13 @@ pub fn test_globals_http_request() -> ZBox<ZendHashTable> {
     ProcessGlobals::get()
         .http_request_vars()
         .unwrap()
+        .unwrap()
         .to_owned()
 }
 
 #[php_function]
 pub fn test_globals_http_files() -> ZBox<ZendHashTable> {
-    ProcessGlobals::get().http_files_vars().to_owned()
+    ProcessGlobals::get().http_files_vars().unwrap().to_owned()
 }
 
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {


### PR DESCRIPTION
## Description

Accessors reading engine- or request-controlled data used to `panic!` inside `extern "C"` frames, aborting the process on adversarial input (non-UTF-8 header bytes, non-array `http_globals` slot). They now return `Option`/`Result`, aligned with `http_server_vars` which already returned `Option`:

- `ProcessGlobals::http_get_vars` / `http_post_vars` / `http_cookie_vars` / `http_env_vars` / `http_files_vars` -> `Option<&ZendHashTable>`
- `ProcessGlobals::http_request_vars` -> `Result<Option<&ZendHashTable>>`: `Err(Error::AutoGlobalLoadFailed)` / `Err(Error::ZvalConversion)` for engine failures, `Ok(None)` for not populated
- `SapiHeader::as_str` / `name` -> `Option<&str>` (`None` on null, empty or non-UTF-8 header, matching `embed::SapiHeader`); `value` propagates
- `zend::php_sapi_name` -> `Option<String>`, with a null-pointer check

Adds the `Error::AutoGlobalLoadFailed(&'static str)` variant. Migration guide updated in `guide/src/migration-guides/v0.16.md`, superglobals guide samples adjusted.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.
