### PR TITLE
fix: reclaim SAPI, exception and arg-info allocations flagged by LSan

### DIFF
--- a/.lsan-suppressions.txt
+++ b/.lsan-suppressions.txt
@@ -1,13 +1,6 @@
 # PHP leaks persistent allocations at embed shutdown by design; php-src's own
 # run-tests gave up on detect_leaks there (run-tests.php:2685).
 leak:libphp
-# Pre-existing library leaks, tracked in
-# docs/plans/2026-07-31-v0.16-breaking-backlog.md (into_raw constructors and
-# bailout-skipped destructors). Remove each entry when its fix lands.
-leak:SapiBuilder
-leak:PhpException>::throw
-leak:ext_php_rs::exception::throw
-leak:as_arg_info
 # Intentional: these tests trigger a PHP bailout on purpose, so their own
 # locals are never dropped.
 leak:test_memory_leak

--- a/guide/src/advanced/custom_sapi.md
+++ b/guide/src/advanced/custom_sapi.md
@@ -120,10 +120,12 @@ let module = MySapi::build_module().expect("failed to build SAPI module");
 The returned `SapiModule` can then be passed to `sapi_startup()` and
 `php_module_startup()` just like a manually-built one.
 
-The builder places the SAPI's `name`, `pretty_name` and related strings on the
-heap. PHP never frees them, so after `sapi_shutdown()` reclaim them with
-`ext_php_rs::embed::cleanup_sapi_allocations` (call it at most once, and only
-on a module built by `SapiBuilder`/`Sapi::build_module`).
+The builder places the SAPI's `name`, `pretty_name`, `executable_location` and
+`php_ini_path_override` strings on the heap. PHP never frees them, so after
+`sapi_shutdown()` reclaim them with `ext_php_rs::embed::cleanup_sapi_allocations`
+(call it at most once, and only on a module built by
+`SapiBuilder`/`Sapi::build_module`). `ini_entries` is not touched: see the
+[INI builder](../ini-builder.md) chapter for who owns it.
 
 ## Registering `$_SERVER` variables
 

--- a/guide/src/advanced/custom_sapi.md
+++ b/guide/src/advanced/custom_sapi.md
@@ -120,6 +120,11 @@ let module = MySapi::build_module().expect("failed to build SAPI module");
 The returned `SapiModule` can then be passed to `sapi_startup()` and
 `php_module_startup()` just like a manually-built one.
 
+The builder places the SAPI's `name`, `pretty_name` and related strings on the
+heap. PHP never frees them, so after `sapi_shutdown()` reclaim them with
+`ext_php_rs::embed::cleanup_sapi_allocations` (call it at most once, and only
+on a module built by `SapiBuilder`/`Sapi::build_module`).
+
 ## Registering `$_SERVER` variables
 
 Override `register_server_variables` in the `Sapi` trait to populate

--- a/guide/src/ini-builder.md
+++ b/guide/src/ini-builder.md
@@ -29,10 +29,20 @@ builder.define("memory_limit=128MB");
 // Prepend INI line text as-is. No line break insertion will occur.
 builder.prepend("error_reporting=0\ndisplay_errors=1\n");
 
-// Construct a SAPI.
+// Construct and start the SAPI.
 let mut sapi = SapiBuilder::new("name", "pretty_name").build()
   .expect("should build SAPI");
+unsafe { sapi_startup(&raw mut sapi) };
 
-// Dump INI entries from the builder into the SAPI.
-sapi.ini_entries = builder.finish();
+// Hand the INI entries to PHP before the engine starts.
+sapi.ini_entries = builder.finish().as_ptr();
+unsafe { php_module_startup(&raw mut sapi, get_module()) };
 # }
+```
+
+`sapi_startup` clears `ini_entries` before copying the module, so the
+assignment has to happen between `sapi_startup` and `php_module_startup`, which
+is where php-src's own SAPIs set it. `SapiBuilder::ini_entries` is discarded by
+that clear for the same reason. The buffer stays owned by the `IniBuilder`: keep
+the builder alive until `php_module_startup` has returned, and do not expect
+`cleanup_sapi_allocations` to free it.

--- a/src/args.rs
+++ b/src/args.rs
@@ -452,6 +452,8 @@ mod tests {
 
         let r#type = arg_info.type_;
         assert_eq!(r#type.type_mask, 16);
+
+        unsafe { drop(CString::from_raw(arg_info.name.cast_mut())) };
     }
 
     #[test]
@@ -466,6 +468,11 @@ mod tests {
 
         let r#type = arg_info.type_;
         assert_eq!(r#type.type_mask, 16);
+
+        unsafe {
+            drop(CString::from_raw(arg_info.name.cast_mut()));
+            drop(CString::from_raw(arg_info.default_value.cast_mut()));
+        }
     }
 
     #[test]

--- a/src/builders/sapi.rs
+++ b/src/builders/sapi.rs
@@ -308,9 +308,14 @@ impl SapiBuilder {
 
     /// Set the `ini_entries` for this SAPI
     ///
+    /// `sapi_startup` clears `ini_entries` before copying the module, so entries
+    /// set here only survive on a module that is never started. To hand INI
+    /// entries to PHP, assign `ini_entries` on the module after `sapi_startup`
+    /// and before `php_module_startup`, as php-src's own SAPIs do.
+    ///
     /// # Parameters
     ///
-    /// * `entries` - A pointer to the ini entries.
+    /// * `entries` - The ini entries.
     pub fn ini_entries<E: Into<String>>(mut self, entries: E) -> Self {
         self.ini_entries = Some(entries.into());
         self
@@ -865,6 +870,12 @@ mod test {
             unsafe { CStr::from_ptr(sapi.ini_entries) },
             c"foo=bar\nmemory_limit=\"128M\"\n"
         );
+
+        #[cfg(php83)]
+        let ini_entries = sapi.ini_entries.cast_mut();
+        #[cfg(not(php83))]
+        let ini_entries = sapi.ini_entries;
+        unsafe { drop(CString::from_raw(ini_entries)) };
     }
 
     #[test]

--- a/src/builders/sapi.rs
+++ b/src/builders/sapi.rs
@@ -468,7 +468,27 @@ extern "C" fn dummy_send_header(_header: *mut sapi_header_struct, _server_contex
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::embed::cleanup_sapi_allocations;
     use std::ffi::CStr;
+    use std::ops::Deref;
+
+    struct CleanupGuard(SapiModule);
+
+    impl Drop for CleanupGuard {
+        fn drop(&mut self) {
+            // SAFETY: The module was built by `SapiBuilder` and was never
+            // passed to `sapi_startup`, so this frees each pointer once.
+            unsafe { cleanup_sapi_allocations(&raw mut self.0) };
+        }
+    }
+
+    impl Deref for CleanupGuard {
+        type Target = SapiModule;
+
+        fn deref(&self) -> &SapiModule {
+            &self.0
+        }
+    }
 
     extern "C" fn test_startup(_sapi: *mut SapiModule) -> c_int {
         0
@@ -524,6 +544,7 @@ mod test {
     fn test_basic_sapi_builder() {
         let sapi = SapiBuilder::new("test_sapi", "Test SAPI")
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert_eq!(
@@ -545,6 +566,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .startup_function(test_startup)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.startup.is_some());
@@ -559,6 +581,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .shutdown_function(test_shutdown)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.shutdown.is_some());
@@ -573,6 +596,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .activate_function(test_activate)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.activate.is_some());
@@ -587,6 +611,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .deactivate_function(test_deactivate)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.deactivate.is_some());
@@ -601,6 +626,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .ub_write_function(test_ub_write)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.ub_write.is_some());
@@ -615,6 +641,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .flush_function(test_flush)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.flush.is_some());
@@ -629,6 +656,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .getenv_function(test_getenv)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.getenv.is_some());
@@ -648,6 +676,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .send_header_function(test_send_header)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.send_header.is_some());
@@ -662,6 +691,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .send_headers_function(test_send_headers)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.send_headers.is_some());
@@ -677,6 +707,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .read_post_function(test_read_post)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.read_post.is_some());
@@ -691,6 +722,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .read_cookies_function(test_read_cookies)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.read_cookies.is_some());
@@ -706,6 +738,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .register_server_variables_function(test_register_server_variables)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.register_server_variables.is_some());
@@ -722,6 +755,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .log_message_function(test_log_message)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.log_message.is_some());
@@ -736,6 +770,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .get_request_time_function(test_get_request_time)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.get_request_time.is_some());
@@ -751,6 +786,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .terminate_process_function(test_terminate_process)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.terminate_process.is_some());
@@ -766,6 +802,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .get_target_uid_function(test_get_target_uid)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.get_target_uid.is_some());
@@ -781,6 +818,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .get_target_gid_function(test_get_target_gid)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.get_target_gid.is_some());
@@ -797,6 +835,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .pre_request_init_function(test_pre_request_init)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(sapi.pre_request_init.is_some());
@@ -818,6 +857,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .ini_entries(ini)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(!sapi.ini_entries.is_null());
@@ -832,6 +872,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .php_ini_path_override("/custom/path/php.ini")
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(!sapi.php_ini_path_override.is_null());
@@ -846,6 +887,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .php_ini_ignore(1)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert_eq!(sapi.php_ini_ignore, 1);
@@ -856,6 +898,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .php_ini_ignore_cwd(1)
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert_eq!(sapi.php_ini_ignore_cwd, 1);
@@ -866,6 +909,7 @@ mod test {
         let sapi = SapiBuilder::new("test", "Test")
             .executable_location("/usr/bin/php")
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert!(!sapi.executable_location.is_null());
@@ -879,6 +923,7 @@ mod test {
     fn test_default_functions_set() {
         let sapi = SapiBuilder::new("test", "Test")
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         // Test that default functions are set
@@ -902,6 +947,7 @@ mod test {
             .php_ini_ignore(1)
             .executable_location("/test/php")
             .build()
+            .map(CleanupGuard)
             .expect("should build sapi module");
 
         assert_eq!(unsafe { CStr::from_ptr(sapi.name) }, c"chained");

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -28,7 +28,7 @@ use std::ptr::null_mut;
 
 pub use context::{RequestInfo, ServerContext};
 pub use ffi::*;
-pub use sapi::SapiModule;
+pub use sapi::{SapiModule, cleanup_sapi_allocations};
 pub use sapi_trait::{Sapi, SapiHeader, SapiHeaders, SendHeadersResult};
 pub use server_vars::ServerVarRegistrar;
 pub use thread::PhpThreadGuard;

--- a/src/embed/sapi.rs
+++ b/src/embed/sapi.rs
@@ -1,6 +1,9 @@
 //! Builder and objects for creating modules in PHP. A module is the base of a
 //! PHP extension.
 
+use std::ffi::CString;
+use std::ptr;
+
 use crate::ffi::sapi_module_struct;
 
 /// A Zend module entry, also known as an extension.
@@ -15,5 +18,47 @@ impl SapiModule {
     #[must_use]
     pub fn into_raw(self) -> *mut Self {
         Box::into_raw(Box::new(self))
+    }
+}
+
+/// Frees every string allocation that
+/// [`SapiBuilder`](crate::builders::SapiBuilder) placed inside a
+/// [`SapiModule`]: `name`, `pretty_name`, `executable_location`, `ini_entries`
+/// and `php_ini_path_override`.
+///
+/// # Safety
+///
+/// * `module` must point to a valid [`SapiModule`] built by `SapiBuilder`.
+///   Calling this on a module built by hand or by C is UB.
+/// * Must be called **at most once**, and only after `sapi_shutdown`: PHP's
+///   global `sapi_module` copy shares these pointers until then.
+pub unsafe fn cleanup_sapi_allocations(module: *mut SapiModule) {
+    let module = unsafe { &mut *module };
+
+    if !module.name.is_null() {
+        unsafe { drop(CString::from_raw(module.name)) };
+        module.name = ptr::null_mut();
+    }
+    if !module.pretty_name.is_null() {
+        unsafe { drop(CString::from_raw(module.pretty_name)) };
+        module.pretty_name = ptr::null_mut();
+    }
+    if !module.executable_location.is_null() {
+        unsafe { drop(CString::from_raw(module.executable_location)) };
+        module.executable_location = ptr::null_mut();
+    }
+    if !module.ini_entries.is_null() {
+        // Safety report from Clippy: `ini_entries` is `*mut c_char` on PHP
+        // 8.1/8.2 and `*const c_char` on 8.3+, so an `as` cast is the only
+        // spelling that compiles on every supported version.
+        #[allow(clippy::ptr_cast_constness)]
+        unsafe {
+            drop(CString::from_raw(module.ini_entries as *mut _));
+        }
+        module.ini_entries = ptr::null_mut();
+    }
+    if !module.php_ini_path_override.is_null() {
+        unsafe { drop(CString::from_raw(module.php_ini_path_override)) };
+        module.php_ini_path_override = ptr::null_mut();
     }
 }

--- a/src/embed/sapi.rs
+++ b/src/embed/sapi.rs
@@ -21,10 +21,15 @@ impl SapiModule {
     }
 }
 
-/// Frees every string allocation that
+/// Frees the string allocations that
 /// [`SapiBuilder`](crate::builders::SapiBuilder) placed inside a
-/// [`SapiModule`]: `name`, `pretty_name`, `executable_location`, `ini_entries`
-/// and `php_ini_path_override`.
+/// [`SapiModule`]: `name`, `pretty_name`, `executable_location` and
+/// `php_ini_path_override`. PHP only reads these and never frees them.
+///
+/// `ini_entries` is left untouched: `sapi_startup` clears it before copying
+/// the module, so after startup it holds whatever the embedder assigned
+/// (typically an [`IniBuilder`](crate::builders::IniBuilder) buffer) and stays
+/// theirs to free.
 ///
 /// # Safety
 ///
@@ -46,16 +51,6 @@ pub unsafe fn cleanup_sapi_allocations(module: *mut SapiModule) {
     if !module.executable_location.is_null() {
         unsafe { drop(CString::from_raw(module.executable_location)) };
         module.executable_location = ptr::null_mut();
-    }
-    if !module.ini_entries.is_null() {
-        // Safety report from Clippy: `ini_entries` is `*mut c_char` on PHP
-        // 8.1/8.2 and `*const c_char` on 8.3+, so an `as` cast is the only
-        // spelling that compiles on every supported version.
-        #[allow(clippy::ptr_cast_constness)]
-        unsafe {
-            drop(CString::from_raw(module.ini_entries as *mut _));
-        }
-        module.ini_entries = ptr::null_mut();
     }
     if !module.php_ini_path_override.is_null() {
         unsafe { drop(CString::from_raw(module.php_ini_path_override)) };

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,6 +1,6 @@
 //! Types and functions used for throwing exceptions from Rust to PHP.
 
-use std::{ffi::CString, fmt::Debug, panic::AssertUnwindSafe, ptr};
+use std::{fmt::Debug, ptr};
 
 use crate::{
     class::RegisteredClass,
@@ -8,8 +8,8 @@ use crate::{
     ffi::zend_throw_exception_ex,
     ffi::zend_throw_exception_object,
     flags::ClassFlags,
-    types::Zval,
-    zend::{ClassEntry, bailout, ce, try_catch},
+    types::{ZendStr, Zval},
+    zend::{ClassEntry, ce},
 };
 
 /// Result type with the error variant as a [`PhpException`].
@@ -165,10 +165,6 @@ pub fn throw(ex: &ClassEntry, message: &str) -> Result<()> {
 /// Returns a result containing nothing if the exception was successfully
 /// thrown.
 ///
-/// If the throw triggers a PHP bailout (e.g. thrown without an active stack
-/// frame), this function never returns: the bailout is caught, the message
-/// allocation is released, and the bailout is re-raised.
-///
 /// # Parameters
 ///
 /// * `ex` - The exception type to throw.
@@ -196,20 +192,21 @@ pub fn throw_with_code(ex: &ClassEntry, code: i32, message: &str) -> Result<()> 
         return Err(Error::InvalidException(flags));
     }
 
-    let message = CString::new(message)?;
-    let ex_ptr = ptr::from_ref(ex).cast_mut();
+    let message = ZendStr::new(message, false);
+    let message_ptr = message.as_c_str()?.as_ptr();
 
-    let result = try_catch(AssertUnwindSafe(|| {
-        // SAFETY: We are given a reference to a `ClassEntry` therefore when we
-        // cast it to a pointer it will be valid.
-        unsafe { zend_throw_exception_ex(ex_ptr, code.into(), c"%s".as_ptr(), message.as_ptr()) };
-    }));
-    drop(message);
-    if result.is_err() {
-        // SAFETY: Re-raises the bailout interrupted above; every local in this
-        // frame has been dropped.
-        unsafe { bailout() };
-    }
+    // SAFETY: We are given a reference to a `ClassEntry` therefore when we cast it
+    // to a pointer it will be valid. `message` is NUL-terminated and outlives the
+    // call; if the engine bails out here the Zend allocator reclaims it at request
+    // shutdown, as php-src does for its own copy of the message.
+    unsafe {
+        zend_throw_exception_ex(
+            ptr::from_ref(ex).cast_mut(),
+            code.into(),
+            c"%s".as_ptr(),
+            message_ptr,
+        )
+    };
     Ok(())
 }
 

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,6 +1,6 @@
 //! Types and functions used for throwing exceptions from Rust to PHP.
 
-use std::{ffi::CString, fmt::Debug, ptr};
+use std::{ffi::CString, fmt::Debug, panic::AssertUnwindSafe, ptr};
 
 use crate::{
     class::RegisteredClass,
@@ -9,7 +9,7 @@ use crate::{
     ffi::zend_throw_exception_object,
     flags::ClassFlags,
     types::Zval,
-    zend::{ClassEntry, ce},
+    zend::{ClassEntry, bailout, ce, try_catch},
 };
 
 /// Result type with the error variant as a [`PhpException`].
@@ -165,6 +165,10 @@ pub fn throw(ex: &ClassEntry, message: &str) -> Result<()> {
 /// Returns a result containing nothing if the exception was successfully
 /// thrown.
 ///
+/// If the throw triggers a PHP bailout (e.g. thrown without an active stack
+/// frame), this function never returns: the bailout is caught, the message
+/// allocation is released, and the bailout is re-raised.
+///
 /// # Parameters
 ///
 /// * `ex` - The exception type to throw.
@@ -192,16 +196,20 @@ pub fn throw_with_code(ex: &ClassEntry, code: i32, message: &str) -> Result<()> 
         return Err(Error::InvalidException(flags));
     }
 
-    // SAFETY: We are given a reference to a `ClassEntry` therefore when we cast it
-    // to a pointer it will be valid.
-    unsafe {
-        zend_throw_exception_ex(
-            ptr::from_ref(ex).cast_mut(),
-            code.into(),
-            CString::new("%s")?.as_ptr(),
-            CString::new(message)?.as_ptr(),
-        )
-    };
+    let message = CString::new(message)?;
+    let ex_ptr = ptr::from_ref(ex).cast_mut();
+
+    let result = try_catch(AssertUnwindSafe(|| {
+        // SAFETY: We are given a reference to a `ClassEntry` therefore when we
+        // cast it to a pointer it will be valid.
+        unsafe { zend_throw_exception_ex(ex_ptr, code.into(), c"%s".as_ptr(), message.as_ptr()) };
+    }));
+    drop(message);
+    if result.is_err() {
+        // SAFETY: Re-raises the bailout interrupted above; every local in this
+        // frame has been dropped.
+        unsafe { bailout() };
+    }
     Ok(())
 }
 

--- a/tests/sapi.rs
+++ b/tests/sapi.rs
@@ -11,8 +11,9 @@ extern crate ext_php_rs;
 use ext_php_rs::builders::SapiBuilder;
 use ext_php_rs::embed::{
     Embed, RequestInfo, Sapi, SapiHeader, SapiHeaders, SendHeadersResult, ServerContext,
-    ServerVarRegistrar, ext_php_rs_sapi_shutdown, ext_php_rs_sapi_startup, worker_request_shutdown,
-    worker_request_startup, worker_reset_superglobals,
+    ServerVarRegistrar, cleanup_sapi_allocations, ext_php_rs_sapi_shutdown,
+    ext_php_rs_sapi_startup, worker_request_shutdown, worker_request_startup,
+    worker_reset_superglobals,
 };
 use ext_php_rs::ffi::{
     ZEND_RESULT_CODE_SUCCESS, php_module_shutdown, php_module_startup, php_request_shutdown,
@@ -112,6 +113,8 @@ fn test_sapi() {
 
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }
 
@@ -220,6 +223,8 @@ fn test_sapi_multithread() {
 
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }
 
@@ -364,6 +369,8 @@ fn test_php_thread_guard_drop() {
     }
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }
 
@@ -416,6 +423,8 @@ fn test_server_var_registrar() {
     }
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }
 
@@ -458,6 +467,8 @@ fn test_sapi_trait_lifecycle() {
     }
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }
 
@@ -508,6 +519,8 @@ fn test_worker_request_cycle() {
     }
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }
 
@@ -579,6 +592,8 @@ fn test_full_sapi_worker_flow() {
     }
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }
 
@@ -645,5 +660,7 @@ fn test_sapi_trait_captures_headers() {
     }
     unsafe {
         ext_php_rs_sapi_shutdown();
+        cleanup_sapi_allocations(sapi);
+        drop(Box::from_raw(sapi));
     }
 }


### PR DESCRIPTION
## Description

Removes the three fixable `.lsan-suppressions.txt` entries by fixing the leaks they covered:

- `throw_with_code` now catches a bailout, drops its message `CString`, and re-raises it (php-src's `zend_catch { cleanup; zend_bailout(); }` idiom, see `ext/soap/soap.c`). The `"%s"` format is a static C literal.
- New `embed::cleanup_sapi_allocations` reclaims the strings `SapiBuilder::build` places in a `SapiModule` (PHP never frees them; call after `sapi_shutdown`). Used by the sapi unit and integration tests, documented in the custom SAPI guide.
- The `as_arg_info` tests free the `CString`s they drop; the library path was already reclaimed by `cleanup_module_allocations`.

Only `leak:libphp` and the intentional-bailout test entries remain suppressed.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [ ] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.