### PR TITLE
fix(cargo-php): Allow unresolved Zend symbols when linking on macOS

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -12,4 +12,7 @@ fn main() {
     // to remain unresolved.
     #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-arg-bins=-Wl,--unresolved-symbols=ignore-in-object-files");
+
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg-bins=-Wl,-undefined,dynamic_lookup");
 }


### PR DESCRIPTION
Fixes #773

Adds the macOS counterpart to the existing Linux flag in `crates/cli/build.rs`:

```rust
#[cfg(target_os = "macos")]
println!("cargo:rustc-link-arg-bins=-Wl,-undefined,dynamic_lookup");
```

The unresolved symbols come from `wrapper.c` functions cargo-php never calls (stubs generation only dlopens the extension and reads its metadata), so leaving them unresolved is safe.

Tested on macOS 26 / Rust 1.96: install fails before, succeeds after; `cargo php stubs` works end to end with Homebrew PHP 8.5 (no embed SAPI).

Thanks a lot for the project!
