### PR TITLE
ci(release-plz): skip the semver check for cargo-php

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -14,6 +14,14 @@ git_release_body = """
 name = "ext-php-rs"
 publish_features = ["enum", "runtime", "closure", "embed", "anyhow"]
 
+# `cargo-php` is a CLI: its lib target is an implementation detail, not a public
+# API. The check is also unrunnable, since it builds the published baseline with
+# all features and 0.1.21 still forwards `runtime` and `static` to `ext-php-rs`,
+# which clang-sys refuses to combine.
+[[package]]
+name = "cargo-php"
+semver_check = false
+
 [changelog]
 header = "# Changelog"
 body = """


### PR DESCRIPTION
## Description

`release-plz` is failing on `master`, which blocks every release: [run 34279673112](https://github.com/extphprs/ext-php-rs/actions/runs/34279673112/job/102247445123).

`cargo-semver-checks` builds the published baseline `cargo-php 0.1.21` with all of its features:

```
cargo add --path .../cargo-php --features default,enum,runtime,static
→ clang-sys build script panicked: `runtime` and `static` features can't be combined
```

0.1.21 (April) still forwards `runtime` and `static` to `ext-php-rs`. Since #775 `cargo-php` no longer depends on `ext-php-rs` and declares no features at all, so the current build is clean and only the baseline fails. The baseline cannot be replaced while release-plz is blocked, so the check is unrunnable.

`cargo-php` is a CLI: its lib target is an implementation detail, not a public API.

## Checklist

- [x] I have read the contribution guidelines and the code of conduct.
- [ ] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [ ] I have added a migration guide if applicable.