### PR TITLE
fix(builders): resolve the parent class entry only when registering a class

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,7 +385,7 @@ jobs:
         # intercepts every allocation once USE_ZEND_ALLOC routes ZendMM
         # through malloc. Doctests cannot build with -Zbuild-std, hence --lib.
         # module_tests adds a registered module, so the argument info tables
-        # owned by util::retain are exercised and must report as reachable.
+        # owned by `StaticModuleEntry` are exercised and must report as reachable.
         # Class, enum and INI registration are not covered here: MINIT cannot
         # run inside Embed's request. See CONTEXT.md for the cdylib recipe.
         env:

--- a/guide/src/migration-guides/v0.16.md
+++ b/guide/src/migration-guides/v0.16.md
@@ -674,3 +674,10 @@ IniEntryDef::register(INI.as_slice(), mod_num);
 
 `IniEntryDefs<N>` exists because `IniEntryDef` holds raw pointers and an array of
 them is not `Sync` on its own.
+
+### `From<Arg> for ZendExpectedType` removed
+
+`impl From<Arg<'_>> for _zend_expected_type` is gone. It existed only to feed
+`zend_wrong_parameter_type_error`, which ext-php-rs never calls: argument
+mismatches go through `ArgParser`, which raises the error itself. Call
+`zend_wrong_parameter_type_error` through `ext_php_rs::ffi` if you relied on it.

--- a/src/builders/class.rs
+++ b/src/builders/class.rs
@@ -387,20 +387,25 @@ impl ClassBuilder {
         // The engine keeps `zend_internal_function.arg_info` pointing into these
         // for the life of the process, so `register` parks them. Holding them in
         // a `ManuallyDrop` keeps them alive across registration, which reads
-        // them, without a second owner.
+        // them, without a second owner. Every fallible step below runs after the
+        // class entry is in `CG(class_table)`, so an error must leak the tables
+        // rather than dangle the functions the engine already holds.
         let arg_info = ManuallyDrop::new(arg_info.into_boxed_slice());
 
         methods.push(FunctionEntry::end());
         let entries = Box::into_raw(methods.into_boxed_slice());
         self.ce.info.internal.builtin_functions = entries.cast::<FunctionEntry>().cast_const();
 
-        let parent = match self.extends {
-            Some((ptr, _)) => ptr::from_ref(ptr()).cast_mut(),
-            None => std::ptr::null_mut(),
-        };
         let class = if self.ce.flags().contains(ClassFlags::Interface) {
             unsafe { zend_register_internal_interface(&raw mut self.ce) }
         } else {
+            // Resolved here and not before the branch: the getter is usually
+            // `T::get_metadata().ce()`, which panics when the parent has not been
+            // registered, and `zend_register_internal_interface` takes no parent.
+            let parent = match self.extends {
+                Some((ptr, _)) => ptr::from_ref(ptr()).cast_mut(),
+                None => std::ptr::null_mut(),
+            };
             unsafe { zend_register_internal_class_ex(&raw mut self.ce, parent) }
         };
 

--- a/src/builders/enum_builder.rs
+++ b/src/builders/enum_builder.rs
@@ -112,15 +112,16 @@ impl EnumBuilder {
             arg_info.push(args);
         }
 
-        // The engine keeps `zend_internal_function.arg_info` pointing into these
-        // for the life of the process, so `register` parks them.
-        let arg_info = ManuallyDrop::new(arg_info.into_boxed_slice());
-
         methods.push(FunctionEntry::end());
 
         let name = CString::new(self.name)?;
         let backing_type = self.datatype.as_u32().try_into()?;
         let entries = Box::into_raw(methods.into_boxed_slice());
+
+        // The engine keeps `zend_internal_function.arg_info` pointing into these
+        // for the life of the process, so `register` parks them. Wrapped only once
+        // the fallible steps are done, so an early return still drops them.
+        let arg_info = ManuallyDrop::new(arg_info.into_boxed_slice());
 
         let class = unsafe {
             zend_register_internal_enum(

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,6 @@
 mod cstring_scope;
 
+// `CStringScope` is only reachable through `builders::ini`, itself gated on
+// `php82` and the `embed` feature, so the re-export is unused elsewhere.
+#[allow(unused_imports)]
 pub use cstring_scope::CStringScope;

--- a/tests/module.rs
+++ b/tests/module.rs
@@ -49,8 +49,8 @@ fn test_module() {
 
         // The engine keeps `arg_info[i].name` and `.default_value` by pointer for
         // the life of the process, so reflecting over a registered function reads
-        // the tables `util::retain` owns. Under LSan this is what proves they are
-        // still reachable rather than lost.
+        // the tables `StaticModuleEntry` owns. Under LSan this is what proves they
+        // are still reachable rather than lost.
         let reflected = Embed::eval(
             "$out = (function () {
                  $r = new ReflectionFunction('greet');
@@ -78,8 +78,8 @@ pub fn hello_world(name: String) -> String {
 }
 
 /// Registers an argument carrying a name, a default value and a declared type,
-/// plus a declared return type, so the retained `arg_info` table has something
-/// to hold.
+/// plus a declared return type, so the `ModuleAllocations` arg-info table has
+/// something to hold.
 #[php_function]
 #[php(defaults(name = "world".to_string()))]
 pub fn greet(name: String) -> String {


### PR DESCRIPTION
## Description

Review follow-up on #778.

- `ClassBuilder::register` resolved the parent entry before branching, so the getter ran for interfaces too. It is usually `T::get_metadata().ce()`, which panics when the parent is not registered yet, and `zend_register_internal_interface` takes no parent. Resolved inside the class branch only.
- `EnumBuilder::register` wrapped the arg-info tables in `ManuallyDrop` before `CString::new(self.name)?` and the backing-type conversion, leaking them on those two error paths. Wrapped after them instead. `ClassBuilder` keeps its wrap where it is: every fallible step below it runs once the class entry is in `CG(class_table)` and points at those tables, so leaking is the only sound outcome there. Now stated in the comment.
- `src/util/mod.rs` lost `#[allow(unused_imports)]`. `CStringScope` is only reachable through `builders::ini`, gated on `php82` and `embed`, so a build without them warns. Restored with the reason.
- Comments in `.github/workflows/build.yml` and `tests/module.rs` still pointed at `util::retain`, removed by the last commits of #778. They now name `StaticModuleEntry` and `ModuleAllocations`.
- Documented the removal of `impl From<Arg<'_>> for _zend_expected_type` in the v0.16 migration guide.

## Checklist

- [x] I have read the contribution guidelines and the code of conduct.
- [ ] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a migration guide if applicable.