### PR TITLE
fix(error)!: rebuild the error model around a Send + Sync Error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Mago
         uses: nhedger/setup-mago@v2
         with:
-          version: 1.47.6
+          version: 1.48.0
       - name: Check PHP formatting
         run: mago format --check
       - name: Lint PHP

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = { version = "1", optional = true }
 smartstring = { version = "1", optional = true }
 indexmap = { version = "2", optional = true }
 inventory = "0.3"
+thiserror = "2"
 ext-php-rs-derive = { version = "=0.11.14", path = "./crates/macros" }
 ext-php-rs-introspection = { version = "0.1.0", path = "./crates/introspection" }
 

--- a/crates/macros/src/enum_.rs
+++ b/crates/macros/src/enum_.rs
@@ -238,7 +238,7 @@ impl<'a> Enum<'a> {
                 fn from_name(name: &str) -> ::ext_php_rs::error::Result<Self> {
                     match name {
                         #(#case_from_names,)*
-                        _ => Err(::ext_php_rs::error::Error::InvalidProperty),
+                        _ => Err(::ext_php_rs::error::Error::InvalidEnumCase { case: name.to_string() }),
                     }
                 }
 
@@ -282,7 +282,7 @@ impl<'a> Enum<'a> {
                         #(
                             #cases,
                         )*
-                        _ => Err(::ext_php_rs::error::Error::InvalidProperty),
+                        _ => Err(::ext_php_rs::error::Error::InvalidEnumCase { case: value.to_string() }),
                     }
                 }
             }

--- a/crates/macros/src/function.rs
+++ b/crates/macros/src/function.rs
@@ -434,7 +434,7 @@ impl<'a> Function<'a> {
                         let this = match this {
                             Some(this) => this,
                             None => {
-                                ::ext_php_rs::exception::PhpException::default("Failed to retrieve reference to `$this`".into())
+                                ::ext_php_rs::exception::PhpException::from_message("Failed to retrieve reference to `$this`".into())
                                     .throw()
                                     .unwrap();
                                 return;
@@ -560,7 +560,7 @@ impl<'a> Function<'a> {
                 match #from_zval {
                     Some(val) => val,
                     None => {
-                        ::ext_php_rs::exception::PhpException::default(
+                        ::ext_php_rs::exception::PhpException::from_message(
                             concat!("Invalid value given for argument `", stringify!(#name), "`.").into()
                         ).throw().expect("Failed to throw PHP exception.");
                         return;
@@ -570,7 +570,7 @@ impl<'a> Function<'a> {
         };
 
         let throw_invalid = quote! {
-            ::ext_php_rs::exception::PhpException::default(
+            ::ext_php_rs::exception::PhpException::from_message(
                 concat!("Invalid value given for argument `", stringify!(#name), "`.").into()
             ).throw().expect("Failed to throw PHP exception.");
             return;
@@ -670,7 +670,7 @@ impl<'a> Function<'a> {
         let arg_names: Vec<_> = self.args.typed.iter().map(|arg| arg.name).collect();
 
         let this_error = quote! {
-            ::ext_php_rs::exception::PhpException::default(
+            ::ext_php_rs::exception::PhpException::from_message(
                 "Failed to retrieve reference to `$this`".into()
             ).throw().unwrap();
             return;
@@ -1116,7 +1116,7 @@ impl TypedArg<'_> {
                     )
                 });
                 let bail_invalid = bail_fn(quote! {
-                    ::ext_php_rs::exception::PhpException::default(
+                    ::ext_php_rs::exception::PhpException::from_message(
                         concat!("Invalid value given for argument `", stringify!(#name), "`.").into()
                     )
                 });
@@ -1156,7 +1156,7 @@ impl TypedArg<'_> {
             }
         } else {
             let bail = bail_fn(quote! {
-                ::ext_php_rs::exception::PhpException::default(
+                ::ext_php_rs::exception::PhpException::from_message(
                     concat!("Invalid value given for argument `", stringify!(#name), "`.").into()
                 )
             });

--- a/crates/macros/src/impl_interface.rs
+++ b/crates/macros/src/impl_interface.rs
@@ -231,7 +231,7 @@ fn generate_method_builder(
                         Some(v) => v,
                         None => {
                             let msg = format!("Invalid value for argument `{}`", #php_name);
-                            ::ext_php_rs::exception::PhpException::default(msg.into())
+                            ::ext_php_rs::exception::PhpException::from_message(msg.into())
                                 .throw()
                                 .expect("Failed to throw PHP exception.");
                             return;
@@ -353,7 +353,7 @@ fn generate_method_builder(
             let this = match this {
                 Some(this) => this,
                 None => {
-                    ::ext_php_rs::exception::PhpException::default("Failed to get $this".into())
+                    ::ext_php_rs::exception::PhpException::from_message("Failed to get $this".into())
                         .throw()
                         .expect("Failed to throw PHP exception.");
                     return;
@@ -379,7 +379,7 @@ fn generate_method_builder(
             let this = match this {
                 Some(this) => this,
                 None => {
-                    ::ext_php_rs::exception::PhpException::default("Failed to get $this".into())
+                    ::ext_php_rs::exception::PhpException::from_message("Failed to get $this".into())
                         .throw()
                         .expect("Failed to throw PHP exception.");
                     return;

--- a/crates/macros/tests/expand/enum.expanded.rs
+++ b/crates/macros/tests/expand/enum.expanded.rs
@@ -80,7 +80,11 @@ impl ::ext_php_rs::enum_::RegisteredEnum for MyEnum {
             "Variant1" => Ok(Self::Variant1),
             "Variant_2" => Ok(Self::Variant2),
             "VARIANT_3" => Ok(Self::Variant3),
-            _ => Err(::ext_php_rs::error::Error::InvalidProperty),
+            _ => {
+                Err(::ext_php_rs::error::Error::InvalidEnumCase {
+                    case: name.to_string(),
+                })
+            }
         }
     }
     fn to_name(&self) -> &'static str {
@@ -156,7 +160,11 @@ impl ::ext_php_rs::enum_::RegisteredEnum for MyEnumWithIntValues {
         match name {
             "Variant1" => Ok(Self::Variant1),
             "Variant2" => Ok(Self::Variant2),
-            _ => Err(::ext_php_rs::error::Error::InvalidProperty),
+            _ => {
+                Err(::ext_php_rs::error::Error::InvalidEnumCase {
+                    case: name.to_string(),
+                })
+            }
         }
     }
     fn to_name(&self) -> &'static str {
@@ -172,7 +180,11 @@ impl TryFrom<i64> for MyEnumWithIntValues {
         match value {
             1i64 => Ok(Self::Variant1),
             42i64 => Ok(Self::Variant2),
-            _ => Err(::ext_php_rs::error::Error::InvalidProperty),
+            _ => {
+                Err(::ext_php_rs::error::Error::InvalidEnumCase {
+                    case: value.to_string(),
+                })
+            }
         }
     }
 }
@@ -249,7 +261,11 @@ impl ::ext_php_rs::enum_::RegisteredEnum for MyEnumWithStringValues {
         match name {
             "Variant1" => Ok(Self::Variant1),
             "Variant2" => Ok(Self::Variant2),
-            _ => Err(::ext_php_rs::error::Error::InvalidProperty),
+            _ => {
+                Err(::ext_php_rs::error::Error::InvalidEnumCase {
+                    case: name.to_string(),
+                })
+            }
         }
     }
     fn to_name(&self) -> &'static str {
@@ -265,7 +281,11 @@ impl TryFrom<&str> for MyEnumWithStringValues {
         match value {
             "foo" => Ok(Self::Variant1),
             "bar" => Ok(Self::Variant2),
-            _ => Err(::ext_php_rs::error::Error::InvalidProperty),
+            _ => {
+                Err(::ext_php_rs::error::Error::InvalidEnumCase {
+                    case: value.to_string(),
+                })
+            }
         }
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -56,10 +56,10 @@
       # local dev and CI (nhedger/setup-mago) run the exact same version.
       mago = pkgs.stdenvNoCC.mkDerivation rec {
         pname = "mago";
-        version = "1.47.6";
+        version = "1.48.0";
         src = pkgs.fetchurl {
           url = "https://github.com/carthage-software/mago/releases/download/${version}/mago-${version}-x86_64-unknown-linux-musl.tar.gz";
-          hash = "sha256-1A7DxEHspUvhsbpU/hdTD41CTS3CP4x8puptppq25Zg=";
+          hash = "sha256-WLWhtJuBTvez2+keEAsGCmysCp4g1FNeAzEj9Vs2RDo=";
         };
         installPhase = ''
           runHook preInstall

--- a/guide/src/exceptions.md
+++ b/guide/src/exceptions.md
@@ -9,7 +9,7 @@ in Rust) is currently being worked on.
 message contained in the exception, the type of exception and a status code to
 go along with the exception.
 
-You can create a new exception with the `new()`, `default()`, or
+You can create a new exception with the `new()`, `from_message()`, or
 `from_class::<T>()` methods. `Into<PhpException>` is implemented for `String`
 and `&str`, which creates an exception of the type `Exception` with a code of 0.
 It may be useful to implement `Into<PhpException>` for your error type.
@@ -18,6 +18,26 @@ Calling the `throw()` method on a `PhpException` attempts to throw the exception
 in PHP. This function can fail if the type of exception is invalid (i.e. does
 not implement `Exception` or `Throwable`). Upon success, nothing will be
 returned.
+
+`throw()` does nothing when an exception is already pending in the engine: that
+one keeps propagating with its own class and stack trace. This is what lets a
+PHP exception caught by `ZendCallable::try_call` reach the caller unchanged even
+though the Rust side reports it as `Error::ExceptionPending`.
+
+To look at the pending exception from Rust, read its class with
+`ExecutorGlobals::pending_exception_class()`, or borrow the object through the
+globals guard, which must outlive the borrow:
+
+```rust,ignore
+let globals = ExecutorGlobals::get();
+if let Some(exception) = globals.exception() {
+    // inspect it; it stays owned by the engine
+}
+```
+
+To handle it yourself, take ownership with `ExecutorGlobals::take_exception()`:
+the engine then stops propagating it and rethrowing becomes your
+responsibility.
 
 `IntoZval` is also implemented for `Result<T, E>`, where `T: IntoZval` and
 `E: Into<PhpException>`. If the result contains the error variant, the exception

--- a/guide/src/migration-guides/v0.16.md
+++ b/guide/src/migration-guides/v0.16.md
@@ -702,3 +702,135 @@ name it turned on both halves of the pair and could never build the crate, which
 in turn blocked the release tooling that runs it.
 
 `runtime` is unchanged and stays the default.
+
+## The Error Model
+
+### `Error` is now `Send + Sync`
+
+`Error::Exception(ZBox<ZendObject>)` is gone. It was the only variant holding
+engine memory, and it made the crate-wide `Result` unusable with threads or
+`anyhow`, which requires `Send + Sync + 'static`.
+
+`ZendCallable::try_call` and friends keep their signatures. When the callable
+throws, the exception stays in the executor globals and the call returns
+`Error::ExceptionPending { class }`. Returning to PHP propagates the original
+exception with its class, message and stack trace; a Rust caller that wants to
+handle it takes ownership with `ExecutorGlobals::take_exception()`.
+
+```rust,ignore
+// v0.15
+match callable.try_call(vec![]) {
+    Err(Error::Exception(obj)) => { /* the exception object */ }
+    _ => {}
+}
+
+// v0.16
+match callable.try_call(vec![]) {
+    Err(Error::ExceptionPending { class }) => {
+        let obj = ExecutorGlobals::take_exception();
+    }
+    _ => {}
+}
+```
+
+`PhpException::throw` is now a no-op when an exception is already pending, so a
+Rust error can never bury the PHP exception that caused it.
+
+### Error messages are lowercase fragments
+
+Every `Display` implementation follows the Rust convention: lowercase, no
+trailing period. `Error::InvalidScope` prints `invalid scope`, not
+`Invalid scope.`. Exception messages produced from an `Error` change to match.
+
+### Variants that carry context
+
+| v0.15 | v0.16 |
+|---|---|
+| `Error::InvalidProperty` | `Error::InvalidProperty { property: String }` |
+| `Error::InvalidCString` | `Error::InvalidCString { position: usize }` |
+| `Error::InvalidProperty` (enum case lookup) | `Error::InvalidEnumCase { case: String }` |
+| `Error::InvalidProperty` (array key conversion) | `Error::ZvalConversion(DataType::String)` |
+| `Error::InvalidProperty` (`ArrayKey::ZendString` that is not UTF-8) | `Error::InvalidUtf8` |
+| `Error::InvalidProperty` (object passed to an enum conversion is not an enum) | `Error::ZvalConversion(DataType::Object(None))` |
+| `Error::UnknownDatatype(0)` from `TryFrom<ZvalTypeFlags>` | `Error::InvalidTypeToDatatype(flags)` |
+
+`Error::UnknownDatatype` is removed. It only ever appeared with a hardcoded `0`
+from the conversion above, which discarded the real flag bits.
+
+`Error::Catch(CatchError)` is new: `try_catch` failures convert into it with
+`?`, and `source()` reports whether the engine bailed out or the result pointer
+was null.
+
+### `CatchError` and `EmbedError` are printable
+
+Both now implement `Display` and `std::error::Error`. `CatchError` is an enum
+with `Bailout` and `NullPanicPtr` instead of a unit struct that meant either.
+`EmbedError::InitError`, which was never constructed, is gone, and
+`EmbedError::CatchError` went from a unit variant to one carrying the
+`CatchError` that caused it:
+
+```rust,ignore
+// v0.15
+Err(EmbedError::CatchError) => { /* was it a bailout? no way to tell */ }
+
+// v0.16
+Err(EmbedError::CatchError(CatchError::Bailout)) => { /* ... */ }
+```
+
+`CatchError`, `EmbedError` and `PhpEvalError` are now `#[non_exhaustive]`, so a
+downstream `match` on any of them needs a wildcard arm. `WorkerError` already
+was.
+
+### `PhpException::default` is now `from_message`
+
+The inherent `default` shadowed `Default::default` while taking an argument.
+
+```rust,ignore
+// v0.15
+PhpException::default("something went wrong".into());
+
+// v0.16
+PhpException::from_message("something went wrong".into());
+```
+
+`throw_object` now validates that the zval holds an object and returns
+`Err(Error::Object)` otherwise, instead of letting the engine raise a fatal
+error.
+
+### Argument and return-type builders report a conversion error
+
+`Arg::as_arg_info` and `FunctionBuilder`'s return-type path returned
+`Error::InvalidCString` when `ZendType::empty_from_type` could not represent a
+type, which had nothing to do with C strings. They now return
+`Error::ZvalConversion(ty)` naming the type that could not be represented.
+
+### `ExecutorGlobals::throw_if_exception` builds the exception directly
+
+It used to go through `Error::Exception` and `From<Error> for PhpException`. It
+now takes the exception and attaches it to the `PhpException` itself, so the
+class and stack trace survive without a round trip through `Error`. The
+signature, `PhpResult<()>`, is unchanged.
+
+### `Function::function_type` returns a `Result`
+
+`From<u8> for FunctionType` panicked on a value read straight out of
+`zend_function`. It is now `TryFrom<u8>`, and `function_type()` returns
+`Result<FunctionType>` with `Error::UnknownFunctionType`.
+
+### `ZendHashTable::remove` returns the removed value
+
+`remove` and `remove_index` returned `Option<()>`, a boolean in costume. They
+now return `Option<Zval>`, matching `OccupiedEntry::remove`.
+
+```rust,ignore
+// v0.15
+ht.remove("key");
+
+// v0.16
+let removed: Option<Zval> = ht.remove("key");
+```
+
+### `StreamWrapper::register` no longer panics on a NUL byte
+
+`register` and `unregister` returned a `Result` but panicked when the wrapper
+name contained a NUL byte. They now return `Error::InvalidCString`.

--- a/src/args.rs
+++ b/src/args.rs
@@ -166,7 +166,7 @@ impl<'a> Arg<'a> {
                 self.variadic,
                 self.allow_null,
             )
-            .ok_or(Error::InvalidCString)?,
+            .ok_or(Error::ZvalConversion(self.r#type))?,
             default_value: match &self.default_value {
                 Some(val) if val.as_str() == "None" => CString::new("null")?.into_raw(),
                 Some(val) => CString::new(val.as_str())?.into_raw(),

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -51,6 +51,28 @@ impl<T: ZBoxable> ZBox<T> {
         Self(unsafe { NonNull::new_unchecked(ptr) })
     }
 
+    /// Creates a new box from a pointer returned by a Zend allocation.
+    ///
+    /// # Parameters
+    ///
+    /// * `ptr` - A well-aligned pointer to a `T`, freshly allocated by the
+    ///   engine.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `ptr` is well-aligned and pointing to a `T`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the engine returned a null pointer.
+    #[expect(
+        clippy::expect_used,
+        reason = "the Zend allocator aborts the process on OOM, so the pointer is never null"
+    )]
+    pub(crate) unsafe fn from_zend_alloc(ptr: *mut T) -> Self {
+        Self(NonNull::new(ptr).expect("the Zend allocator returned a null pointer"))
+    }
+
     /// Returns the pointer contained by the box, dropping the box in the
     /// process. The data pointed to by the returned pointer is not
     /// released.

--- a/src/builders/class.rs
+++ b/src/builders/class.rs
@@ -257,7 +257,7 @@ impl ClassBuilder {
                 // are called if a bailout occurs (issue #537)
                 let catch_result = try_catch(AssertUnwindSafe(|| {
                     let Some(ConstructorMeta { constructor, .. }) = T::constructor() else {
-                        let _ = PhpException::default("You cannot instantiate this class from PHP.".into())
+                        let _ = PhpException::from_message("You cannot instantiate this class from PHP.".into())
                             .throw();
                         return;
                     };
@@ -274,7 +274,7 @@ impl ClassBuilder {
                     // Use get_object_uninit because the Rust backing is not yet initialized.
                     // We need access to the ZendClassObject to call initialize() on it.
                     let Some(this_obj) = ex.get_object_uninit::<T>() else {
-                        let _ = PhpException::default("Failed to retrieve reference to `this` object.".into())
+                        let _ = PhpException::from_message("Failed to retrieve reference to `this` object.".into())
                             .throw();
                         return;
                     };

--- a/src/builders/function.rs
+++ b/src/builders/function.rs
@@ -191,7 +191,7 @@ impl<'a> FunctionBuilder<'a> {
             type_: match self.retval {
                 Some(retval) => {
                     ZendType::empty_from_type(retval, self.ret_as_ref, false, self.ret_as_null)
-                        .ok_or(Error::InvalidCString)?
+                        .ok_or(Error::ZvalConversion(retval))?
                 }
                 None => ZendType::empty(false, false),
             },

--- a/src/builders/module.rs
+++ b/src/builders/module.rs
@@ -436,6 +436,10 @@ impl ModuleBuilder<'_> {
     /// # Panics
     ///
     /// * Panics if a constant could not be registered.
+    #[expect(
+        clippy::expect_used,
+        reason = "registration runs in MINIT, where a failure is an extension bug the engine cannot recover from"
+    )]
     pub fn interface<T: RegisteredClass>(mut self) -> Self {
         self.interfaces.push(|| {
             let mut builder = ClassBuilder::new(T::CLASS_NAME);
@@ -473,6 +477,10 @@ impl ModuleBuilder<'_> {
     /// # Panics
     ///
     /// * Panics if a constant could not be registered.
+    #[expect(
+        clippy::expect_used,
+        reason = "registration runs in MINIT, where a failure is an extension bug the engine cannot recover from"
+    )]
     pub fn class<T: RegisteredClass>(mut self) -> Self {
         self.classes.push(|| {
             let mut builder = ClassBuilder::new(T::CLASS_NAME);
@@ -640,6 +648,10 @@ impl ModuleStartup {
     /// # Panics
     ///
     /// * Panics if a class could not be registered.
+    #[expect(
+        clippy::expect_used,
+        reason = "registration runs in MINIT, where a failure is an extension bug the engine cannot recover from"
+    )]
     pub fn startup(self, _ty: i32, mod_num: i32) -> Result<()> {
         for (name, val) in self.constants {
             val.register_constant(&name, mod_num)?;

--- a/src/class.rs
+++ b/src/class.rs
@@ -246,6 +246,10 @@ impl<T: RegisteredClass> ClassMetadata<T> {
     /// # Panics
     ///
     /// Panics if there is no class entry stored inside the class metadata.
+    #[expect(
+        clippy::expect_used,
+        reason = "the class entry is written once during MINIT, before any Rust code can reach the metadata"
+    )]
     pub fn ce(&self) -> &'static ClassEntry {
         // SAFETY: There are only two values that can be stored in the atomic
         // ptr: null or a static reference to a class entry. On the null case,
@@ -260,6 +264,10 @@ impl<T: RegisteredClass> ClassMetadata<T> {
     ///
     /// Panics if the class entry has already been set in the class metadata.
     /// This function should only be called once.
+    #[expect(
+        clippy::expect_used,
+        reason = "the class entry is written once during MINIT, before any concurrent access"
+    )]
     pub fn set_ce(&self, ce: &'static mut ClassEntry) {
         self.ce
             .compare_exchange(
@@ -280,6 +288,10 @@ impl<T: RegisteredClass> ClassMetadata<T> {
     /// # Panics
     ///
     /// If the argument info has already been set.
+    #[expect(
+        clippy::expect_used,
+        reason = "the arg info is written once during MINIT, before any concurrent access"
+    )]
     pub fn set_arg_info(&self, arg_info: OwnedArgInfo) {
         self.arg_info
             .set(ArgInfoTables(arg_info))

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -119,6 +119,10 @@ impl Closure {
     /// # Panics
     ///
     /// Panics if the `RustClosure` PHP class cannot be registered.
+    #[expect(
+        clippy::expect_used,
+        reason = "the RustClosure class is registered once during MINIT"
+    )]
     pub fn build() {
         if CLOSURE_META.has_ce() {
             return;
@@ -143,6 +147,7 @@ impl Closure {
 
     zend_fastcall! {
         /// External function used by the Zend interpreter to call the closure.
+        #[expect(clippy::expect_used, reason = "the engine only dispatches this handler on RustClosure instances")]
         extern "C" fn invoke(ex: &mut ExecuteData, ret: &mut Zval) {
             let (parser, this) = ex.parser_method::<Self>();
             let this = this.expect("Internal closure function called on non-closure class");
@@ -213,8 +218,9 @@ where
 {
     fn invoke(&mut self, _: ArgParser, ret: &mut Zval) {
         if let Err(e) = self().set_zval(ret, false) {
-            let _ = PhpException::default(format!("Failed to return closure result to PHP: {e}"))
-                .throw();
+            let _ =
+                PhpException::from_message(format!("Failed to return closure result to PHP: {e}"))
+                    .throw();
         }
     }
 }
@@ -225,8 +231,9 @@ where
 {
     fn invoke(&mut self, _: ArgParser, ret: &mut Zval) {
         if let Err(e) = self().set_zval(ret, false) {
-            let _ = PhpException::default(format!("Failed to return closure result to PHP: {e}"))
-                .throw();
+            let _ =
+                PhpException::from_message(format!("Failed to return closure result to PHP: {e}"))
+                    .throw();
         }
     }
 }
@@ -240,7 +247,7 @@ where
 
         Closure::wrap(Box::new(move || {
             let Some(this) = this.take() else {
-                let _ = PhpException::default(
+                let _ = PhpException::from_message(
                     "Attempted to call `FnOnce` closure more than once.".into(),
                 )
                 .throw();
@@ -267,7 +274,7 @@ macro_rules! php_closure_impl {
 
                 Closure::wrap(Box::new(move |$($gen),*| {
                     let Some(this) = this.take() else {
-                        let _ = PhpException::default(
+                        let _ = PhpException::from_message(
                             "Attempted to call `FnOnce` closure more than once.".into(),
                         )
                         .throw();
@@ -304,7 +311,7 @@ macro_rules! php_closure_impl {
                         match $gen.consume() {
                             Ok(val) => val,
                             _ => {
-                                let _ = PhpException::default(concat!("Invalid parameter type for `", stringify!($gen), "`.").into()).throw();
+                                let _ = PhpException::from_message(concat!("Invalid parameter type for `", stringify!($gen), "`.").into()).throw();
                                 return;
                             }
                         }
@@ -312,7 +319,7 @@ macro_rules! php_closure_impl {
                 );
 
                 if let Err(e) = result.set_zval(ret, false) {
-                    let _ = PhpException::default(format!("Failed to return closure result to PHP: {}", e)).throw();
+                    let _ = PhpException::from_message(format!("Failed to return closure result to PHP: {}", e)).throw();
                 }
             }
         }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -82,10 +82,13 @@ pub trait FromZendObject<'a>: Sized {
     ///
     /// # Errors
     ///
-    /// If the conversion fails, an [`Error`] is returned.
+    /// * [`Error::ZvalConversion`] - If the object is not of the expected
+    ///   class.
+    /// * [`Error::InvalidProperty`] - If a property the conversion needs is
+    ///   missing.
     ///
-    /// [`Error`]: crate::error::Error
-    // TODO: Expand on error information
+    /// [`Error::ZvalConversion`]: crate::error::Error::ZvalConversion
+    /// [`Error::InvalidProperty`]: crate::error::Error::InvalidProperty
     fn from_zend_object(obj: &'a ZendObject) -> Result<Self>;
 }
 
@@ -99,10 +102,13 @@ pub trait FromZendObjectMut<'a>: Sized {
     ///
     /// # Errors
     ///
-    /// If the conversion fails, an [`Error`] is returned.
+    /// * [`Error::ZvalConversion`] - If the object is not of the expected
+    ///   class.
+    /// * [`Error::InvalidProperty`] - If a property the conversion needs is
+    ///   missing.
     ///
-    /// [`Error`]: crate::error::Error
-    // TODO: Expand on error information
+    /// [`Error::ZvalConversion`]: crate::error::Error::ZvalConversion
+    /// [`Error::InvalidProperty`]: crate::error::Error::InvalidProperty
     fn from_zend_object_mut(obj: &'a mut ZendObject) -> Result<Self>;
 }
 
@@ -123,10 +129,13 @@ pub trait IntoZendObject {
     ///
     /// # Errors
     ///
-    /// If the conversion fails, an [`Error`] is returned.
+    /// * [`Error::ZvalConversion`] - If the value has no object
+    ///   representation.
+    /// * [`Error::InvalidScope`] - If the class of the object has not been
+    ///   registered with the engine.
     ///
-    /// [`Error`]: crate::error::Error
-    // TODO: Expand on error information
+    /// [`Error::ZvalConversion`]: crate::error::Error::ZvalConversion
+    /// [`Error::InvalidScope`]: crate::error::Error::InvalidScope
     fn into_zend_object(self) -> Result<ZBox<ZendObject>>;
 }
 
@@ -153,10 +162,16 @@ pub trait IntoZval: Sized {
     ///
     /// # Errors
     ///
-    /// If the conversion fails, an [`Error`] is returned.
+    /// Implementations return the error that describes their failure, for
+    /// example:
     ///
-    /// [`Error`]: crate::error::Error
-    // TODO: Expand on error information
+    /// * [`Error::IntegerOverflow`] - If the value does not fit in a PHP
+    ///   integer.
+    /// * [`Error::InvalidCString`] - If a string in the value contains a NUL
+    ///   byte.
+    ///
+    /// [`Error::IntegerOverflow`]: crate::error::Error::IntegerOverflow
+    /// [`Error::InvalidCString`]: crate::error::Error::InvalidCString
     fn into_zval(self, persistent: bool) -> Result<Zval> {
         let mut zval = Zval::new();
         self.set_zval(&mut zval, persistent)?;
@@ -174,10 +189,16 @@ pub trait IntoZval: Sized {
     ///
     /// # Errors
     ///
-    /// If setting the content fails, an [`Error`] is returned.
+    /// Implementations return the error that describes their failure, for
+    /// example:
     ///
-    /// [`Error`]: crate::error::Error
-    // TODO: Expand on error information
+    /// * [`Error::IntegerOverflow`] - If the value does not fit in a PHP
+    ///   integer.
+    /// * [`Error::InvalidCString`] - If a string in the value contains a NUL
+    ///   byte.
+    ///
+    /// [`Error::IntegerOverflow`]: crate::error::Error::IntegerOverflow
+    /// [`Error::InvalidCString`]: crate::error::Error::InvalidCString
     fn set_zval(self, zv: &mut Zval, persistent: bool) -> Result<()>;
 }
 

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -19,7 +19,7 @@ use crate::ffi::{
     zend_destroy_file_handle, zend_eval_string, zend_file_handle, zend_stream_init_filename,
 };
 use crate::types::{ZendObject, Zval};
-use crate::zend::{ExecutorGlobals, panic_wrapper, try_catch};
+use crate::zend::{CatchError, ExecutorGlobals, panic_wrapper, try_catch};
 use parking_lot::{RwLock, const_rwlock};
 use std::ffi::{CString, NulError, c_char, c_void};
 use std::panic::{AssertUnwindSafe, UnwindSafe, resume_unwind};
@@ -40,27 +40,35 @@ pub use worker::{
 pub struct Embed;
 
 /// Error type for the embed module
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum EmbedError {
-    /// Failed to initialize
-    InitError,
-    /// The script exited with a non-zero code
+    /// The script threw an exception, carried here when the engine still had
+    /// it to give.
+    #[error("the script threw an exception")]
     ExecuteError(Option<ZBox<ZendObject>>),
     /// The script exited with a non-zero code
+    #[error("the script exited with a non-zero code")]
     ExecuteScriptError,
     /// The script is not a valid [`CString`]
-    InvalidEvalString(NulError),
+    #[error("the script is not a valid C string")]
+    InvalidEvalString(#[from] NulError),
     /// Failed to open the script file at the given path
+    #[error("failed to open the script file")]
     InvalidPath,
-    /// The script was executed but an exception was thrown
-    CatchError,
+    /// The engine did not run the script to completion
+    #[error(transparent)]
+    CatchError(#[from] CatchError),
 }
 
 impl EmbedError {
-    /// Check if the error is a bailout
+    /// Check if the engine aborted the run instead of returning from it.
+    ///
+    /// Covers both an explicit bailout and a run whose result never came back,
+    /// since either leaves the interpreter in a state callers must recover from.
     #[must_use]
     pub fn is_bailout(&self) -> bool {
-        matches!(self, EmbedError::CatchError)
+        matches!(self, EmbedError::CatchError(_))
     }
 }
 
@@ -124,7 +132,7 @@ impl Embed {
         unsafe { zend_destroy_file_handle(&raw mut file_handle) }
 
         match exec_result {
-            Err(_) => Err(EmbedError::CatchError),
+            Err(err) => Err(EmbedError::CatchError(err)),
             Ok(true) => Ok(()),
             Ok(false) => Err(EmbedError::ExecuteScriptError),
         }
@@ -232,7 +240,7 @@ impl Embed {
         }));
 
         match exec_result {
-            Err(_) => Err(EmbedError::CatchError),
+            Err(err) => Err(EmbedError::CatchError(err)),
             Ok(ZEND_RESULT_CODE_SUCCESS) => Ok(result),
             Ok(_) => Err(EmbedError::ExecuteError(ExecutorGlobals::take_exception())),
         }

--- a/src/embed/worker.rs
+++ b/src/embed/worker.rs
@@ -3,25 +3,15 @@ use super::ffi::{
     ext_php_rs_worker_reset_superglobals,
 };
 use crate::ffi::ZEND_RESULT_CODE_SUCCESS;
-use std::fmt;
 
 /// Errors from the worker request lifecycle.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum WorkerError {
     /// `worker_request_startup` returned a non-SUCCESS code.
+    #[error("worker request startup failed")]
     StartupFailed,
 }
-
-impl fmt::Display for WorkerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::StartupFailed => write!(f, "Worker request startup failed"),
-        }
-    }
-}
-
-impl std::error::Error for WorkerError {}
 
 /// Run the lightweight request shutdown sequence (output + SAPI teardown).
 ///

--- a/src/enum_.rs
+++ b/src/enum_.rs
@@ -38,7 +38,7 @@ where
     fn from_zend_object(obj: &ZendObject) -> Result<Self> {
         if !ClassFlags::from_bits_truncate(unsafe { (*obj.ce).ce_flags }).contains(ClassFlags::Enum)
         {
-            return Err(Error::InvalidProperty);
+            return Err(Error::ZvalConversion(DataType::Object(None)));
         }
 
         let name = obj
@@ -46,7 +46,9 @@ where
             .get("name")
             .and_then(Zval::indirect)
             .and_then(Zval::str)
-            .ok_or(Error::InvalidProperty)?;
+            .ok_or_else(|| Error::InvalidProperty {
+                property: "name".to_string(),
+            })?;
 
         T::from_name(name)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,176 +1,170 @@
 //! Error and result types returned from the library functions.
 
 use std::{
-    error::Error as ErrorTrait,
     ffi::{CString, NulError, c_int},
-    fmt::Display,
     num::TryFromIntError,
 };
 
 use crate::{
-    boxed::ZBox,
     exception::PhpException,
     ffi::php_error_docref,
     flags::{ClassFlags, DataType, ErrorType, ZvalTypeFlags},
-    types::{ZendObject, Zval},
+    zend::{CatchError, ExecutorGlobals},
 };
 
 /// The main result type which is passed by the library.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync + 'static>() {}
+    assert_send_sync::<Error>();
+};
+
+const _: () = assert!(
+    size_of::<Error>() == size_of::<String>() + size_of::<usize>(),
+    "Error is returned by every Result in the crate, including the conversion paths: a variant that grows it past a String payload is paid for on every call"
+);
+
 /// The main error type which is passed by the library inside the custom
 /// [`Result`] type.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
     /// An incorrect number of arguments was given to a PHP function.
     ///
-    /// The enum carries two integers - the first representing the minimum
-    /// number of arguments expected, and the second representing the number of
-    /// arguments that were received.
+    /// The enum carries two integers - the first representing the number of
+    /// arguments that were received, and the second representing the minimum
+    /// number of arguments expected.
+    #[error("expected at least {1} arguments, got {0} arguments")]
     IncorrectArguments(usize, usize),
     /// There was an error converting a Zval into a primitive type.
     ///
     /// The enum carries the data type of the Zval.
+    #[error("could not convert value of type {0}")]
     ZvalConversion(DataType),
-    /// The type of the Zval is unknown.
+    /// The function type read from the engine is not one this crate models.
     ///
-    /// The enum carries the integer representation of the type of Zval.
-    UnknownDatatype(u32),
+    /// The enum carries the raw value read from `zend_function.type`.
+    #[error("unknown function type {0}")]
+    UnknownFunctionType(u8),
     /// Attempted to convert a [`ZvalTypeFlags`] struct to a [`DataType`].
     /// The flags did not contain a datatype.
     ///
     /// The enum carries the flags that were attempted to be converted to a
     /// [`DataType`].
+    #[error("type flags did not contain a datatype: {0:?}")]
     InvalidTypeToDatatype(ZvalTypeFlags),
     /// The function called was called in an invalid scope (calling
     /// class-related functions inside of a non-class bound function).
+    #[error("invalid scope")]
     InvalidScope,
     /// The pointer inside a given type was invalid, either null or pointing to
     /// garbage.
+    #[error("invalid pointer")]
     InvalidPointer,
     /// The given property name does not exist.
-    InvalidProperty,
+    #[error("property `{property}` does not exist on the object")]
+    InvalidProperty {
+        /// Name of the property that was looked up.
+        property: String,
+    },
+    /// The enum has no case matching the given name or discriminant.
+    #[error("enum has no case matching `{case}`")]
+    InvalidEnumCase {
+        /// Name or discriminant that was looked up.
+        case: String,
+    },
     /// The string could not be converted into a C-string due to the presence of
     /// a NUL character.
-    InvalidCString,
+    #[error("string contains a NUL byte at position {position}")]
+    InvalidCString {
+        /// Byte offset of the first NUL character.
+        position: usize,
+    },
     /// The string could not be converted into a valid Utf8 string
+    #[error("invalid UTF-8 byte sequence")]
     InvalidUtf8,
     /// Could not call the given function.
+    #[error("could not call the given function")]
     Callable,
     /// An object was expected.
+    #[error("an object was expected")]
     Object,
     /// The object's class does not implement `__toString()`, so it cannot be
     /// converted into a string.
     ///
     /// The enum carries the name of the class.
+    #[error("{0} does not implement __toString()")]
     NotStringable(String),
     /// An invalid exception type was thrown.
+    #[error("invalid exception type was thrown: {0:?}")]
     InvalidException(ClassFlags),
     /// Converting integer arguments resulted in an overflow.
+    #[error("converting integer arguments resulted in an overflow")]
     IntegerOverflow,
-    /// An exception was thrown in a function.
-    Exception(ZBox<ZendObject>),
+    /// The engine did not run a [`try_catch`] closure to completion.
+    ///
+    /// [`try_catch`]: crate::zend::try_catch
+    #[error("try_catch did not run the closure to completion")]
+    Catch(#[from] CatchError),
+    /// A PHP exception is pending in the executor globals.
+    ///
+    /// The exception is left where the engine put it, so it propagates on its
+    /// own once control returns to PHP. Take ownership of it with
+    /// [`ExecutorGlobals::take_exception`] to handle it from Rust.
+    ///
+    /// The enum carries the class name of the pending exception.
+    #[error("a PHP exception of class {class} is pending")]
+    ExceptionPending {
+        /// Class name of the pending exception.
+        class: String,
+    },
     /// A failure occurred while registering the stream wrapper
+    #[error("a failure occurred while registering the stream wrapper")]
     StreamWrapperRegistrationFailure,
     /// A failure occurred while unregistering the stream wrapper
+    #[error("a failure occurred while unregistering the stream wrapper")]
     StreamWrapperUnregistrationFailure,
     /// The SAPI write function is not available
+    #[error("the SAPI write function is not available")]
     SapiWriteUnavailable,
     /// Failed to make an object lazy (PHP 8.4+)
+    #[error("failed to make the object lazy")]
     LazyObjectFailed,
     /// The engine failed to load an auto-global.
     ///
     /// The enum carries the name of the auto-global.
+    #[error("the engine failed to load the `{0}` auto-global")]
     AutoGlobalLoadFailed(&'static str),
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::IncorrectArguments(n, expected) => write!(
-                f,
-                "Expected at least {expected} arguments, got {n} arguments."
-            ),
-            Error::ZvalConversion(ty) => write!(
-                f,
-                "Could not convert Zval from type {ty} into primitive type."
-            ),
-            Error::UnknownDatatype(dt) => write!(f, "Unknown datatype {dt}."),
-            Error::InvalidTypeToDatatype(dt) => {
-                write!(f, "Type flags did not contain a datatype: {dt:?}")
-            }
-            Error::InvalidScope => write!(f, "Invalid scope."),
-            Error::InvalidPointer => write!(f, "Invalid pointer."),
-            Error::InvalidProperty => write!(f, "Property does not exist on object."),
-            Error::InvalidCString => write!(
-                f,
-                "String given contains NUL-bytes which cannot be present in a C string."
-            ),
-            Error::InvalidUtf8 => write!(f, "Invalid Utf8 byte sequence."),
-            Error::Callable => write!(f, "Could not call given function."),
-            Error::Object => write!(f, "An object was expected."),
-            Error::NotStringable(class) => {
-                write!(f, "{class} does not implement __toString().")
-            }
-            Error::InvalidException(flags) => {
-                write!(f, "Invalid exception type was thrown: {flags:?}")
-            }
-            Error::IntegerOverflow => {
-                write!(f, "Converting integer arguments resulted in an overflow.")
-            }
-            Error::Exception(e) => write!(f, "Exception was thrown: {e:?}"),
-            Error::StreamWrapperRegistrationFailure => {
-                write!(f, "A failure occurred while registering the stream wrapper")
-            }
-            Error::StreamWrapperUnregistrationFailure => {
-                write!(
-                    f,
-                    "A failure occurred while unregistering the stream wrapper"
-                )
-            }
-            Error::SapiWriteUnavailable => {
-                write!(f, "The SAPI write function is not available")
-            }
-            Error::LazyObjectFailed => {
-                write!(f, "Failed to make the object lazy")
-            }
-            Error::AutoGlobalLoadFailed(name) => {
-                write!(f, "The engine failed to load the `{name}` auto-global.")
-            }
-        }
-    }
-}
-
-impl ErrorTrait for Error {}
-
-impl From<NulError> for Error {
-    fn from(_: NulError) -> Self {
-        Self::InvalidCString
+impl Error {
+    /// Builds an [`Error::ExceptionPending`] from the exception the engine is
+    /// currently holding, leaving the exception where it is.
+    ///
+    /// Returns [`None`] when no exception is pending.
+    pub(crate) fn pending_exception() -> Option<Self> {
+        ExecutorGlobals::pending_exception_class().map(|class| Self::ExceptionPending { class })
     }
 }
 
 impl From<TryFromIntError> for Error {
-    fn from(_value: TryFromIntError) -> Self {
+    fn from(_: TryFromIntError) -> Self {
         Self::IntegerOverflow
+    }
+}
+
+impl From<NulError> for Error {
+    fn from(value: NulError) -> Self {
+        Self::InvalidCString {
+            position: value.nul_position(),
+        }
     }
 }
 
 impl From<Error> for PhpException {
     fn from(err: Error) -> Self {
-        match err {
-            Error::Exception(mut obj) => {
-                let message = obj.get_class_name().unwrap_or_else(|_| "Exception".into());
-                let mut zv = Zval::new();
-                // `set_object` increments the refcount and the `ZBox` releases its own
-                // when it drops, so the zval ends up owning exactly the one reference
-                // `obj` held. Attaching it keeps the original class, message and stack
-                // trace instead of flattening them into a string.
-                zv.set_object(&mut obj);
-                Self::default(message).with_object(zv)
-            }
-            err => Self::default(err.to_string()),
-        }
+        Self::from_message(err.to_string())
     }
 }
 
@@ -194,5 +188,64 @@ pub fn php_error(type_: &ErrorType, message: &str) {
     // are NUL-terminated and outlive the call.
     unsafe {
         php_error_docref(std::ptr::null(), bits, c"%s".as_ptr(), c_string.as_ptr());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use super::*;
+
+    #[test]
+    fn exception_pending_names_the_class() {
+        let err = Error::ExceptionPending {
+            class: "RuntimeException".into(),
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "a PHP exception of class RuntimeException is pending"
+        );
+    }
+
+    #[test]
+    fn catch_error_is_chained_as_a_source() {
+        let err: Error = CatchError::Bailout.into();
+
+        assert_eq!(
+            err.to_string(),
+            "try_catch did not run the closure to completion"
+        );
+        assert_eq!(
+            err.source().map(ToString::to_string),
+            Some("the engine bailed out".to_string())
+        );
+    }
+
+    #[test]
+    fn invalid_cstring_reports_the_nul_position() {
+        let err: Error = CString::new("a\0b")
+            .expect_err("the string has a NUL")
+            .into();
+
+        assert_eq!(err.to_string(), "string contains a NUL byte at position 1");
+    }
+
+    #[test]
+    fn invalid_property_names_the_property() {
+        let err = Error::InvalidProperty {
+            property: "age".into(),
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "property `age` does not exist on the object"
+        );
+    }
+
+    #[test]
+    fn messages_are_lowercase_fragments() {
+        assert_eq!(Error::InvalidScope.to_string(), "invalid scope");
     }
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -9,7 +9,7 @@ use crate::{
     ffi::zend_throw_exception_object,
     flags::ClassFlags,
     types::{ZendStr, Zval},
-    zend::{ClassEntry, ce},
+    zend::{ClassEntry, ExecutorGlobals, ce},
 };
 
 /// Result type with the error variant as a [`PhpException`].
@@ -19,9 +19,9 @@ pub type PhpResult<T = ()> = std::result::Result<T, PhpException>;
 /// Primarily used to return from a [`Result<T, PhpException>`] which can
 /// immediately be thrown by the `ext-php-rs` macro API.
 ///
-/// There are default [`From`] implementations for any type that implements
-/// [`ToString`], so these can also be returned from these functions. You can
-/// also implement [`From<T>`] for your custom error type.
+/// [`From`] is implemented for [`String`], [`&str`], [`crate::error::Error`]
+/// and, behind the `anyhow` feature, `anyhow::Error`. Implement [`From<T>`]
+/// for your own error type to return it from these functions.
 #[derive(Debug)]
 pub struct PhpException {
     message: String,
@@ -48,7 +48,7 @@ impl PhpException {
         }
     }
 
-    /// Creates a new default exception instance, using the default PHP
+    /// Creates a new exception instance from a message, using the default PHP
     /// `Exception` type as the exception type, with an integer code of
     /// zero.
     ///
@@ -56,7 +56,7 @@ impl PhpException {
     ///
     /// * `message` - Message to contain in the exception.
     #[must_use]
-    pub fn default(message: String) -> Self {
+    pub fn from_message(message: String) -> Self {
         Self::new(message, 0, ce::exception())
     }
 
@@ -99,12 +99,19 @@ impl PhpException {
     /// Throws the exception, returning nothing inside a result if successful
     /// and an error otherwise.
     ///
+    /// Does nothing if an exception is already pending: the engine propagates
+    /// that one, and throwing over it would discard its class and stack trace.
+    ///
     /// # Errors
     ///
     /// * [`Error::InvalidException`] - If the exception type is an interface or
     ///   abstract class.
     /// * If the message contains NUL bytes.
     pub fn throw(self) -> Result<()> {
+        if ExecutorGlobals::has_exception() {
+            return Ok(());
+        }
+
         match self.object {
             Some(object) => throw_object(object),
             None => throw_with_code(self.ex, self.code, &self.message),
@@ -114,13 +121,13 @@ impl PhpException {
 
 impl From<String> for PhpException {
     fn from(str: String) -> Self {
-        Self::default(str)
+        Self::from_message(str)
     }
 }
 
 impl From<&str> for PhpException {
     fn from(str: &str) -> Self {
-        Self::default(str.into())
+        Self::from_message(str.into())
     }
 }
 
@@ -221,8 +228,7 @@ pub fn throw_with_code(ex: &ClassEntry, code: i32, message: &str) -> Result<()> 
 ///
 /// # Errors
 ///
-/// *shrug*
-/// TODO: does this error?
+/// * [`Error::Object`] - If the zval does not hold an object.
 ///
 /// # Examples
 ///
@@ -251,6 +257,10 @@ pub fn throw_with_code(ex: &ClassEntry, code: i32, message: &str) -> Result<()> 
 /// throw_object( error.into_zval(true).unwrap() );
 /// ```
 pub fn throw_object(zval: Zval) -> Result<()> {
+    if !zval.is_object() {
+        return Err(Error::Object);
+    }
+
     let mut zv = core::mem::ManuallyDrop::new(zval);
     unsafe { zend_throw_exception_object(core::ptr::addr_of_mut!(zv).cast()) };
     Ok(())
@@ -277,7 +287,7 @@ mod tests {
     #[test]
     fn test_default() {
         Embed::run(|| {
-            let ex = PhpException::default("Test".into());
+            let ex = PhpException::from_message("Test".into());
             assert_eq!(ex.message, "Test");
             assert_eq!(ex.code, 0);
             assert_eq!(ex.ex, ce::exception());
@@ -288,7 +298,7 @@ mod tests {
     #[test]
     fn test_set_object() {
         Embed::run(|| {
-            let mut ex = PhpException::default("Test".into());
+            let mut ex = PhpException::from_message("Test".into());
             assert!(ex.object.is_none());
             let obj = Zval::new();
             ex.set_object(Some(obj));
@@ -300,7 +310,7 @@ mod tests {
     fn test_with_object() {
         Embed::run(|| {
             let obj = Zval::new();
-            let ex = PhpException::default("Test".into()).with_object(obj);
+            let ex = PhpException::from_message("Test".into()).with_object(obj);
             assert!(ex.object.is_some());
         });
     }
@@ -308,7 +318,7 @@ mod tests {
     #[test]
     fn test_throw_code() {
         Embed::run(|| {
-            let ex = PhpException::default("Test".into());
+            let ex = PhpException::from_message("Test".into());
             assert!(ex.throw().is_ok());
 
             assert!(false, "Should not reach here");
@@ -316,12 +326,11 @@ mod tests {
     }
 
     #[test]
-    fn test_throw_object() {
+    fn test_throw_object_rejects_a_non_object() {
         Embed::run(|| {
-            let ex = PhpException::default("Test".into()).with_object(Zval::new());
-            assert!(ex.throw().is_ok());
+            let ex = PhpException::from_message("Test".into()).with_object(Zval::new());
 
-            assert!(false, "Should not reach here");
+            assert!(matches!(ex.throw(), Err(Error::Object)));
         });
     }
 
@@ -386,12 +395,9 @@ mod tests {
     }
 
     #[test]
-    fn test_static_throw_object() {
+    fn test_static_throw_object_rejects_a_non_object() {
         Embed::run(|| {
-            let obj = Zval::new();
-            assert!(throw_object(obj).is_ok());
-
-            assert!(false, "Should not reach here");
+            assert!(matches!(throw_object(Zval::new()), Err(Error::Object)));
         });
     }
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -346,14 +346,16 @@ pub enum FunctionType {
     Eval,
 }
 
-impl From<u8> for FunctionType {
+impl TryFrom<u8> for FunctionType {
+    type Error = Error;
+
     #[allow(clippy::bad_bit_mask)]
-    fn from(value: u8) -> Self {
+    fn try_from(value: u8) -> Result<Self> {
         match value.into() {
-            ZEND_INTERNAL_FUNCTION => Self::Internal,
-            ZEND_USER_FUNCTION => Self::User,
-            ZEND_EVAL_CODE => Self::Eval,
-            _ => panic!("Unknown function type: {value}"),
+            ZEND_INTERNAL_FUNCTION => Ok(Self::Internal),
+            ZEND_USER_FUNCTION => Ok(Self::User),
+            ZEND_EVAL_CODE => Ok(Self::Eval),
+            _ => Err(Error::UnknownFunctionType(value)),
         }
     }
 }
@@ -472,19 +474,21 @@ impl TryFrom<ZvalTypeFlags> for DataType {
             return Ok(DataType::Object(None));
         }
 
-        Err(Error::UnknownDatatype(0))
+        Err(Error::InvalidTypeToDatatype(value))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DataType, DataTypeExt};
+    use super::{DataType, DataTypeExt, FunctionType};
+    use crate::error::Error;
     use crate::ffi::{
         IS_ARRAY, IS_ARRAY_EX, IS_CONSTANT_AST, IS_CONSTANT_AST_EX, IS_DOUBLE, IS_FALSE,
         IS_INDIRECT, IS_INTERNED_STRING_EX, IS_LONG, IS_NULL, IS_OBJECT, IS_OBJECT_EX, IS_PTR,
         IS_REFERENCE, IS_REFERENCE_EX, IS_RESOURCE, IS_RESOURCE_EX, IS_STRING, IS_STRING_EX,
         IS_TRUE, IS_UNDEF, IS_VOID,
     };
+    use crate::ffi::{ZEND_EVAL_CODE, ZEND_INTERNAL_FUNCTION, ZEND_USER_FUNCTION};
     #[test]
     fn test_datatype() {
         macro_rules! test {
@@ -516,5 +520,27 @@ mod tests {
         test!(IS_RESOURCE_EX, Resource);
         test!(IS_REFERENCE_EX, Reference);
         test!(IS_CONSTANT_AST_EX, ConstantExpression);
+    }
+
+    #[test]
+    fn function_type_maps_the_engine_constants() {
+        let cases = [
+            (ZEND_INTERNAL_FUNCTION, FunctionType::Internal),
+            (ZEND_USER_FUNCTION, FunctionType::User),
+            (ZEND_EVAL_CODE, FunctionType::Eval),
+        ];
+
+        for (raw, expected) in cases {
+            let ty = FunctionType::try_from(u8::try_from(raw).expect("fits in u8"));
+
+            assert_eq!(ty.ok(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn function_type_rejects_an_unknown_value() {
+        let err = FunctionType::try_from(u8::MAX);
+
+        assert!(matches!(err, Err(Error::UnknownFunctionType(u8::MAX))));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![deny(clippy::unwrap_used)]
+#![cfg_attr(not(test), deny(clippy::expect_used))]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/php_eval.rs
+++ b/src/php_eval.rs
@@ -23,39 +23,26 @@
 use crate::ffi;
 use crate::types::ZendStr;
 use crate::zend::try_catch;
-use std::fmt;
 use std::mem;
 use std::panic::AssertUnwindSafe;
 
 /// Errors that can occur when executing embedded PHP code.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PhpEvalError {
     /// The code does not start with a `<?php` open tag.
+    #[error("PHP code must start with a <?php open tag")]
     MissingOpenTag,
     /// PHP failed to compile the code (syntax error).
+    #[error("PHP compilation failed (syntax error)")]
     CompilationFailed,
     /// The code executed but threw an unhandled exception.
+    #[error("PHP execution threw an unhandled exception")]
     ExecutionFailed,
     /// A PHP fatal error (bailout) occurred during execution.
+    #[error("PHP fatal error (bailout) during execution")]
     Bailout,
 }
-
-impl fmt::Display for PhpEvalError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PhpEvalError::MissingOpenTag => {
-                write!(f, "PHP code must start with a <?php open tag")
-            }
-            PhpEvalError::CompilationFailed => write!(f, "PHP compilation failed (syntax error)"),
-            PhpEvalError::ExecutionFailed => {
-                write!(f, "PHP execution threw an unhandled exception")
-            }
-            PhpEvalError::Bailout => write!(f, "PHP fatal error (bailout) during execution"),
-        }
-    }
-}
-
-impl std::error::Error for PhpEvalError {}
 
 /// Execute embedded PHP code within the running PHP engine.
 ///

--- a/src/types/array/array_key.rs
+++ b/src/types/array/array_key.rs
@@ -52,16 +52,15 @@ impl TryFrom<ArrayKey<'_>> for i64 {
     type Error = Error;
 
     fn try_from(value: ArrayKey<'_>) -> Result<Self, Self::Error> {
-        match value {
-            ArrayKey::Long(i) => Ok(i),
-            ArrayKey::String(s) => s.parse::<i64>().map_err(|_| Error::InvalidProperty),
-            ArrayKey::Str(s) => s.parse::<i64>().map_err(|_| Error::InvalidProperty),
-            ArrayKey::ZendString(s) => s
-                .as_str()
-                .map_err(|_| Error::InvalidProperty)?
-                .parse::<i64>()
-                .map_err(|_| Error::InvalidProperty),
-        }
+        let key = match &value {
+            ArrayKey::Long(i) => return Ok(*i),
+            ArrayKey::String(s) => s.as_str(),
+            ArrayKey::Str(s) => s,
+            ArrayKey::ZendString(s) => s.as_str().map_err(|_| Error::InvalidUtf8)?,
+        };
+
+        key.parse::<i64>()
+            .map_err(|_| Error::ZvalConversion(DataType::String))
     }
 }
 
@@ -226,7 +225,7 @@ mod tests {
         let key = ArrayKey::String("not a number".to_string());
         let result: crate::error::Result<i64, _> = key.try_into();
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::InvalidProperty));
+        assert!(matches!(result.unwrap_err(), Error::ZvalConversion(_)));
     }
 
     #[test]

--- a/src/types/array/conversions/btree_map.rs
+++ b/src/types/array/conversions/btree_map.rs
@@ -258,7 +258,7 @@ mod tests {
 
             let map_err: crate::error::Result<BTreeMap<i64, String>> = ht2.as_ref().try_into();
             assert!(map_err.is_err());
-            assert!(matches!(map_err.unwrap_err(), Error::InvalidProperty));
+            assert!(matches!(map_err.unwrap_err(), Error::ZvalConversion(_)));
         });
     }
 

--- a/src/types/array/conversions/hash_map.rs
+++ b/src/types/array/conversions/hash_map.rs
@@ -264,7 +264,7 @@ mod tests {
 
             let map_err: crate::error::Result<HashMap<i64, String>> = ht2.as_ref().try_into();
             assert!(map_err.is_err());
-            assert!(matches!(map_err.unwrap_err(), Error::InvalidProperty));
+            assert!(matches!(map_err.unwrap_err(), Error::ZvalConversion(_)));
         });
     }
 

--- a/src/types/array/conversions/index_map.rs
+++ b/src/types/array/conversions/index_map.rs
@@ -270,7 +270,7 @@ mod tests {
 
             let map_err: crate::error::Result<IndexMap<i64, String>> = ht2.as_ref().try_into();
             assert!(map_err.is_err());
-            assert!(matches!(map_err.unwrap_err(), Error::InvalidProperty));
+            assert!(matches!(map_err.unwrap_err(), Error::ZvalConversion(_)));
         });
     }
 

--- a/src/types/array/conversions/vec.rs
+++ b/src/types/array/conversions/vec.rs
@@ -322,7 +322,7 @@ mod tests {
 
             let vec2: crate::error::Result<Vec<(i64, String)>> = ht2.as_ref().try_into();
             assert!(vec2.is_err());
-            assert!(matches!(vec2.unwrap_err(), Error::InvalidProperty));
+            assert!(matches!(vec2.unwrap_err(), Error::ZvalConversion(_)));
         });
     }
 

--- a/src/types/array/entry.rs
+++ b/src/types/array/entry.rs
@@ -458,9 +458,12 @@ impl<'a, 'k> OccupiedEntry<'a, 'k> {
     ///     assert!(ht.get("key").is_none());
     /// }
     /// ```
+    #[expect(
+        clippy::must_use_candidate,
+        reason = "the removal is the point, the returned value is optional"
+    )]
     pub fn remove_entry(self) -> (ArrayKey<'k>, Option<Zval>) {
-        let value = self.get().map(Zval::shallow_clone);
-        self.ht.remove(self.key.clone());
+        let value = self.ht.remove(self.key.clone());
         (self.key, value)
     }
 
@@ -488,10 +491,12 @@ impl<'a, 'k> OccupiedEntry<'a, 'k> {
     ///     assert_eq!(value.str(), Some("value"));
     /// }
     /// ```
+    #[expect(
+        clippy::must_use_candidate,
+        reason = "the removal is the point, the returned value is optional"
+    )]
     pub fn remove(self) -> Option<Zval> {
-        let value = self.get().map(Zval::shallow_clone);
-        self.ht.remove(self.key);
-        value
+        self.ht.remove(self.key)
     }
 }
 

--- a/src/types/array/iterators.rs
+++ b/src/types/array/iterators.rs
@@ -39,6 +39,10 @@ impl<'a> Iter<'a> {
     ///
     /// Panics if the hashtable length exceeds `i64::MAX`.
     #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "a hash table cannot hold more than i64::MAX elements"
+    )]
     pub fn new(ht: &'a ZendHashTable) -> Self {
         let end_num: i64 = ht
             .len()
@@ -150,6 +154,10 @@ impl<'a> IntoIterator for &'a ZendHashTable {
 impl<'a> Iterator for Iter<'a> {
     type Item = (ArrayKey<'a>, &'a Zval);
 
+    #[expect(
+        clippy::expect_used,
+        reason = "a key read back from the engine is always a valid array key"
+    )]
     fn next(&mut self) -> Option<Self::Item> {
         self.next_zval()
             .map(|(k, v)| (ArrayKey::from_zval(&k).expect("Invalid array key!"), v))

--- a/src/types/array/mod.rs
+++ b/src/types/array/mod.rs
@@ -56,6 +56,15 @@ pub type ZendHashTable = crate::ffi::HashTable;
 // Clippy complains about there being no `is_empty` function when implementing
 // on the alias `ZendStr` :( <https://github.com/rust-lang/rust-clippy/issues/7702>
 #[allow(clippy::len_without_is_empty)]
+/// Copies the value a bucket holds, so it survives the bucket's removal.
+///
+/// A symbol table stores `IS_INDIRECT` zvals pointing at compiled-variable slots;
+/// those are engine-internal and never valid as a returned value, so the copy
+/// is taken from the slot they point to.
+fn removed_value(bucket: &Zval) -> Zval {
+    bucket.indirect().unwrap_or(bucket).shallow_clone()
+}
+
 impl ZendHashTable {
     /// Creates a new, empty, PHP hashtable, returned inside a [`ZBox`].
     ///
@@ -100,11 +109,7 @@ impl ZendHashTable {
             #[allow(clippy::used_underscore_items)]
             let ptr = _zend_new_array(size);
 
-            // SAFETY: `as_mut()` checks if the pointer is null, and panics if it is not.
-            ZBox::from_raw(
-                ptr.as_mut()
-                    .expect("Failed to allocate memory for hashtable"),
-            )
+            ZBox::from_zend_alloc(ptr)
         }
     }
 
@@ -361,7 +366,7 @@ impl ZendHashTable {
     ///
     /// # Returns
     ///
-    /// * `Some(())` - Key was successfully removed.
+    /// * `Some(value)` - The value that was removed.
     /// * `None` - No key was removed, did not exist.
     ///
     /// # Example
@@ -374,14 +379,16 @@ impl ZendHashTable {
     /// ht.insert("test", "hello world");
     /// assert_eq!(ht.len(), 1);
     ///
-    /// ht.remove("test");
+    /// assert_eq!(ht.remove("test").and_then(|v| v.string()), Some("hello world".to_string()));
     /// assert_eq!(ht.len(), 0);
     /// ```
-    pub fn remove<'a, K>(&mut self, key: K) -> Option<()>
+    pub fn remove<'a, K>(&mut self, key: K) -> Option<Zval>
     where
         K: Into<ArrayKey<'a>>,
     {
-        let result = match key.into() {
+        let key = key.into();
+        let removed = self.get(key.clone()).map(removed_value);
+        let result = match key {
             ArrayKey::Long(index) => unsafe {
                 #[allow(clippy::cast_sign_loss)]
                 zend_hash_index_del(self, index as zend_ulong)
@@ -395,7 +402,7 @@ impl ZendHashTable {
             ArrayKey::ZendString(key) => unsafe { zend_hash_del(self, key.as_ptr().cast_mut()) },
         };
 
-        if result < 0 { None } else { Some(()) }
+        if result < 0 { None } else { removed }
     }
 
     /// Attempts to remove a value from the hash table with a string key.
@@ -406,7 +413,7 @@ impl ZendHashTable {
     ///
     /// # Returns
     ///
-    /// * `Ok(())` - Key was successfully removed.
+    /// * `Some(value)` - The value that was removed.
     /// * `None` - No key was removed, did not exist.
     ///
     /// # Example
@@ -419,16 +426,17 @@ impl ZendHashTable {
     /// ht.push("hello");
     /// assert_eq!(ht.len(), 1);
     ///
-    /// ht.remove_index(0);
+    /// assert_eq!(ht.remove_index(0).and_then(|v| v.string()), Some("hello".to_string()));
     /// assert_eq!(ht.len(), 0);
     /// ```
-    pub fn remove_index(&mut self, key: i64) -> Option<()> {
+    pub fn remove_index(&mut self, key: i64) -> Option<Zval> {
+        let removed = self.get(key).map(removed_value);
         let result = unsafe {
             #[allow(clippy::cast_sign_loss)]
             zend_hash_index_del(self, key as zend_ulong)
         };
 
-        if result < 0 { None } else { Some(()) }
+        if result < 0 { None } else { removed }
     }
 
     /// Attempts to insert an item into the hash table, or update if the key
@@ -634,6 +642,10 @@ impl ZendHashTable {
     /// assert!(!ht.has_sequential_keys());
     /// ```
     #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "a hash table cannot hold more than i64::MAX elements"
+    )]
     pub fn has_sequential_keys(&self) -> bool {
         !self
             .into_iter()
@@ -831,11 +843,7 @@ impl ToOwned for ZendHashTable {
             // SAFETY: FFI call does not modify `self`, returns a new hashtable.
             let ptr = zend_array_dup(ptr::from_ref(self).cast_mut());
 
-            // SAFETY: `as_mut()` checks if the pointer is null, and panics if it is not.
-            ZBox::from_raw(
-                ptr.as_mut()
-                    .expect("Failed to allocate memory for hashtable"),
-            )
+            ZBox::from_zend_alloc(ptr)
         }
     }
 }

--- a/src/types/callable.rs
+++ b/src/types/callable.rs
@@ -7,7 +7,6 @@ use crate::{
     error::{Error, Result},
     ffi::_call_user_function_impl,
     flags::DataType,
-    zend::ExecutorGlobals,
 };
 
 use super::{ZendHashTable, Zval};
@@ -142,8 +141,8 @@ impl<'a> ZendCallable<'a> {
 
         if result < 0 {
             Err(Error::Callable)
-        } else if let Some(e) = ExecutorGlobals::take_exception() {
-            Err(Error::Exception(e))
+        } else if let Some(e) = Error::pending_exception() {
+            Err(e)
         } else {
             Ok(retval)
         }
@@ -234,8 +233,8 @@ impl<'a> ZendCallable<'a> {
 
         if result < 0 {
             Err(Error::Callable)
-        } else if let Some(e) = ExecutorGlobals::take_exception() {
-            Err(Error::Exception(e))
+        } else if let Some(e) = Error::pending_exception() {
+            Err(e)
         } else {
             Ok(retval)
         }

--- a/src/types/class_object.rs
+++ b/src/types/class_object.rs
@@ -107,6 +107,10 @@ impl<T: RegisteredClass> ZendClassObject<T> {
     /// # Panics
     ///
     /// Panics if memory was unable to be allocated for the new object.
+    #[expect(
+        clippy::expect_used,
+        reason = "the Zend allocator aborts the process on OOM, so the pointer is never null"
+    )]
     unsafe fn internal_new(val: Option<T>, ce: Option<&'static ClassEntry>) -> ZBox<Self> {
         let size = mem::size_of::<ZendClassObject<T>>();
         let meta = T::get_metadata();
@@ -227,6 +231,10 @@ impl<T: RegisteredClass> ZendClassObject<T> {
     /// # Panics
     ///
     /// * If the std offset over/underflows `isize`.
+    #[expect(
+        clippy::expect_used,
+        reason = "the offset is a compile-time struct offset and fits in isize"
+    )]
     unsafe fn resolve(std: *const zend_object, require_initialized: bool) -> Option<*const Self> {
         // First, check if this object was created by our create_object handler.
         // We do this by comparing the handlers pointer. Objects created by PHP's
@@ -315,6 +323,10 @@ unsafe impl<T: RegisteredClass> ZBoxable for ZendClassObject<T> {
 impl<T> Deref for ZendClassObject<T> {
     type Target = T;
 
+    #[expect(
+        clippy::expect_used,
+        reason = "the user data is inlined in the allocation this pointer came from"
+    )]
     fn deref(&self) -> &Self::Target {
         self.obj
             .as_ref()
@@ -323,6 +335,10 @@ impl<T> Deref for ZendClassObject<T> {
 }
 
 impl<T> DerefMut for ZendClassObject<T> {
+    #[expect(
+        clippy::expect_used,
+        reason = "the user data is inlined in the allocation this pointer came from"
+    )]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.obj
             .as_mut()

--- a/src/types/iterable.rs
+++ b/src/types/iterable.rs
@@ -46,6 +46,10 @@ impl<'a> IntoIterator for &'a mut Iterable<'a> {
     type Item = (Zval, Zval);
     type IntoIter = Iter<'a>;
 
+    #[expect(
+        clippy::expect_used,
+        reason = "IntoIterator has no error channel, and a fresh iterator can always be rewound"
+    )]
     fn into_iter(self) -> Self::IntoIter {
         self.iter().expect("Could not rewind iterator!")
     }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -140,6 +140,10 @@ impl<'a> IntoIterator for &'a mut ZendIterator {
     type Item = (Zval, Zval);
     type IntoIter = Iter<'a>;
 
+    #[expect(
+        clippy::expect_used,
+        reason = "IntoIterator has no error channel, and a fresh iterator can always be rewound"
+    )]
     fn into_iter(self) -> Self::IntoIter {
         self.iter().expect("Could not rewind iterator!")
     }
@@ -163,6 +167,10 @@ pub struct Iter<'a> {
 impl Iterator for Iter<'_> {
     type Item = (Zval, Zval);
 
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine keeps the iterator index non-negative and within i64"
+    )]
     fn next(&mut self) -> Option<Self::Item> {
         // Call next when index > 0, so next is really called at the start of each
         // iteration, which allow to work better with generator iterator

--- a/src/types/object.rs
+++ b/src/types/object.rs
@@ -61,7 +61,7 @@ use crate::{
     flags::DataType,
     rc::PhpRc,
     types::{ZendClassObject, ZendStr, Zval},
-    zend::{ClassEntry, ExecutorGlobals, ZendObjectHandlers, ce},
+    zend::{ClassEntry, ZendObjectHandlers, ce},
 };
 
 #[cfg(php84)]
@@ -111,10 +111,7 @@ impl ZendObject {
                 Some(v) => v(ptr::from_ref(ce).cast_mut()),
             };
 
-            ZBox::from_raw(
-                ptr.as_mut()
-                    .expect("Failed to allocate memory for Zend object"),
-            )
+            ZBox::from_zend_alloc(ptr)
         }
     }
 
@@ -158,6 +155,10 @@ impl ZendObject {
     ///
     /// Panics if the class entry is invalid.
     #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "every object the engine hands out carries a class entry"
+    )]
     pub fn get_class_entry(&self) -> &'static ClassEntry {
         // SAFETY: it is OK to panic here since PHP would segfault anyway
         // when encountering an object with no class entry.
@@ -279,7 +280,9 @@ impl ZendObject {
         T: FromZval<'a>,
     {
         if !self.has_property(name, PropertyQuery::Exists)? {
-            return Err(Error::InvalidProperty);
+            return Err(Error::InvalidProperty {
+                property: name.to_string(),
+            });
         }
 
         let mut name = ZendStr::new(name, false);
@@ -782,7 +785,7 @@ impl FromZendObject<'_> for String {
     ///
     /// * [`Error::InvalidPointer`] - If the object has no class entry.
     /// * [`Error::NotStringable`] - If the class does not implement `__toString()`.
-    /// * [`Error::Exception`] - If `__toString()` threw an exception.
+    /// * [`Error::ExceptionPending`] - If `__toString()` threw an exception.
     /// * [`Error::ZvalConversion`] - If `__toString()` did not return a string.
     fn from_zend_object(obj: &ZendObject) -> Result<Self> {
         // SAFETY: every object the engine constructs carries a class entry, but a
@@ -814,8 +817,8 @@ impl FromZendObject<'_> for String {
             );
         }
 
-        if let Some(err) = ExecutorGlobals::take_exception() {
-            return Err(Error::Exception(err));
+        if let Some(err) = Error::pending_exception() {
+            return Err(err);
         }
 
         ret.extract()

--- a/src/types/string/mod.rs
+++ b/src/types/string/mod.rs
@@ -8,7 +8,7 @@ use std::{
     borrow::Cow,
     cmp::Ordering,
     convert::TryFrom,
-    ffi::{CStr, CString},
+    ffi::{CStr, CString, FromBytesWithNulError},
     fmt::Debug,
     hash::{Hash, Hasher},
     ptr, slice,
@@ -83,10 +83,11 @@ impl ZendStr {
     pub fn new(str: impl AsRef<[u8]>, persistent: bool) -> ZBox<Self> {
         let s = str.as_ref();
         unsafe {
-            let ptr = ext_php_rs_zend_string_init(s.as_ptr().cast(), s.len(), persistent)
-                .as_mut()
-                .expect("Failed to allocate memory for new Zend string");
-            ZBox::from_raw(ptr)
+            ZBox::from_zend_alloc(ext_php_rs_zend_string_init(
+                s.as_ptr().cast(),
+                s.len(),
+                persistent,
+            ))
         }
     }
 
@@ -123,13 +124,11 @@ impl ZendStr {
     #[must_use]
     pub fn from_c_str(str: &CStr, persistent: bool) -> ZBox<Self> {
         unsafe {
-            let ptr =
-                ext_php_rs_zend_string_init(str.as_ptr(), str.to_bytes().len() as _, persistent);
-
-            ZBox::from_raw(
-                ptr.as_mut()
-                    .expect("Failed to allocate memory for new Zend string"),
-            )
+            ZBox::from_zend_alloc(ext_php_rs_zend_string_init(
+                str.as_ptr(),
+                str.to_bytes().len() as _,
+                persistent,
+            ))
         }
     }
 
@@ -174,6 +173,10 @@ impl ZendStr {
     ///
     /// let s = ZendStr::new_interned("PHP", true);
     /// ```
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine installs zend_string_init_interned before MINIT runs"
+    )]
     pub fn new_interned(str: impl AsRef<[u8]>, persistent: bool) -> ZBox<Self> {
         let _lock = INTERNED_LOCK.lock();
         let s = str.as_ref();
@@ -229,6 +232,10 @@ impl ZendStr {
     /// let c_s = CString::new("PHP").unwrap();
     /// let s = ZendStr::interned_from_c_str(&c_s, true);
     /// ```
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine installs zend_string_init_interned before MINIT runs"
+    )]
     pub fn interned_from_c_str(str: &CStr, persistent: bool) -> ZBox<Self> {
         let _lock = INTERNED_LOCK.lock();
 
@@ -278,12 +285,17 @@ impl ZendStr {
     ///
     /// # Errors
     ///
-    /// Returns an [`Error::InvalidCString`] variant if the string contains null
-    /// bytes.
+    /// * [`Error::InvalidCString`] - If the string contains an interior NUL
+    ///   byte.
+    /// * [`Error::InvalidPointer`] - If the engine handed out a string without
+    ///   its NUL terminator.
     pub fn as_c_str(&self) -> Result<&CStr> {
         let bytes_with_null =
             unsafe { slice::from_raw_parts(self.val.as_ptr().cast(), self.len() + 1) };
-        CStr::from_bytes_with_nul(bytes_with_null).map_err(|_| Error::InvalidCString)
+        CStr::from_bytes_with_nul(bytes_with_null).map_err(|err| match err {
+            FromBytesWithNulError::InteriorNul { position } => Error::InvalidCString { position },
+            FromBytesWithNulError::NotNulTerminated => Error::InvalidPointer,
+        })
     }
 
     /// Attempts to return a reference to the underlying bytes inside the Zend

--- a/src/zend/class.rs
+++ b/src/zend/class.rs
@@ -96,6 +96,10 @@ impl ClassEntry {
     ///
     /// Panics if the number of interfaces exceeds `isize::MAX`.
     #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "the interface count comes from the engine and fits in isize"
+    )]
     pub fn interfaces(&self) -> Option<impl Iterator<Item = &ClassEntry>> {
         self.flags()
             .contains(ClassFlags::ResolvedInterfaces)
@@ -223,7 +227,9 @@ impl ClassEntry {
         if result == ZEND_RESULT_CODE_SUCCESS {
             Ok(())
         } else {
-            Err(Error::InvalidProperty)
+            Err(Error::InvalidProperty {
+                property: name.to_string_lossy().into_owned(),
+            })
         }
     }
 }

--- a/src/zend/ex.rs
+++ b/src/zend/ex.rs
@@ -233,6 +233,10 @@ impl ExecuteData {
     /// lifetime isn't exceeded.
     #[doc(hidden)]
     #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "argument counts are bounded by the engine's own u32 limit"
+    )]
     pub unsafe fn zend_call_arg<'a>(&self, n: usize) -> Option<&'a mut Zval> {
         let n = isize::try_from(n).expect("n is too large");
         let ptr = unsafe { self.zend_call_var_num(n) };
@@ -258,6 +262,10 @@ impl ExecuteData {
     /// Translation of macro `ZEND_MM_ALIGNED_SIZE(size)`
     /// zend_alloc.h:41
     #[doc(hidden)]
+    #[expect(
+        clippy::expect_used,
+        reason = "the size of a type the engine can allocate fits in isize"
+    )]
     fn zend_mm_aligned_size<T>() -> isize {
         let size = isize::try_from(std::mem::size_of::<T>()).expect("size of T is too large");
         (size + ZEND_MM_ALIGNMENT - 1) & ZEND_MM_ALIGNMENT_MASK

--- a/src/zend/function.rs
+++ b/src/zend/function.rs
@@ -52,9 +52,15 @@ pub type Function = zend_function;
 
 impl Function {
     /// Returns the function type.
-    #[must_use]
-    pub fn function_type(&self) -> FunctionType {
-        FunctionType::from(unsafe { self.type_ })
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::UnknownFunctionType`] - If the engine reports a function type
+    ///   this crate does not model.
+    ///
+    /// [`Error::UnknownFunctionType`]: crate::error::Error::UnknownFunctionType
+    pub fn function_type(&self) -> Result<FunctionType> {
+        FunctionType::try_from(unsafe { self.type_ })
     }
 
     /// Attempts to fetch a [`Function`] from the function name.

--- a/src/zend/globals.rs
+++ b/src/zend/globals.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, LazyLock};
 
 use crate::boxed::ZBox;
 use crate::error::{Error, Result};
-use crate::exception::PhpResult;
+use crate::exception::{PhpException, PhpResult};
 #[cfg(php82)]
 use crate::ffi::zend_atomic_bool_store;
 use crate::ffi::{
@@ -29,9 +29,15 @@ use crate::ffi::{
     zend_known_strings,
 };
 
-use crate::types::{ZendHashTable, ZendObject, ZendStr};
+use crate::types::{ZendHashTable, ZendObject, ZendStr, Zval};
 
 use super::linked_list::ZendLinkedListIterator;
+
+/// Names the class of an exception object, falling back to `Exception` when the
+/// engine cannot report one.
+fn class_name_or_fallback(obj: &ZendObject) -> String {
+    obj.get_class_name().unwrap_or_else(|_| "Exception".into())
+}
 
 /// Stores global variables used in the PHP executor.
 pub type ExecutorGlobals = _zend_executor_globals;
@@ -48,6 +54,10 @@ impl ExecutorGlobals {
     /// # Panics
     ///
     /// * If static executor globals are not set
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine declares these globals statically, so the pointer is valid for the life of the process"
+    )]
     pub fn get() -> GlobalReadGuard<Self> {
         // SAFETY: PHP executor globals are statically declared therefore should never
         // return an invalid pointer.
@@ -76,6 +86,10 @@ impl ExecutorGlobals {
     /// # Panics
     ///
     /// * If static executor globals are not set
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine declares these globals statically, so the pointer is valid for the life of the process"
+    )]
     pub fn get_mut() -> GlobalWriteGuard<Self> {
         // SAFETY: PHP executor globals are statically declared therefore should never
         // return an invalid pointer.
@@ -180,6 +194,28 @@ impl ExecutorGlobals {
         !Self::get().exception.is_null()
     }
 
+    /// Borrows the pending exception without taking ownership of it.
+    ///
+    /// The exception stays in the executor globals, so it keeps propagating on
+    /// its own once control returns to PHP. Use
+    /// [`take_exception`](Self::take_exception) to handle it from Rust instead.
+    #[must_use]
+    pub fn exception(&self) -> Option<&ZendObject> {
+        // SAFETY: the pointer is either null or a valid object owned by the engine,
+        // borrowed for no longer than the globals guard this method is called on.
+        unsafe { self.exception.as_ref() }
+    }
+
+    /// Returns the class name of the pending exception, leaving the exception
+    /// where it is.
+    ///
+    /// Returns [`None`] when no exception is pending. A class the engine cannot
+    /// name is reported as `Exception`.
+    #[must_use]
+    pub fn pending_exception_class() -> Option<String> {
+        Some(class_name_or_fallback(Self::get().exception()?))
+    }
+
     /// Attempts to extract the last PHP exception captured by the interpreter.
     /// Returned inside a [`PhpResult`].
     ///
@@ -192,11 +228,14 @@ impl ExecutorGlobals {
     /// If an exception is present, it will be returned as `Err` value inside a
     /// [`PhpResult`].
     pub fn throw_if_exception() -> PhpResult<()> {
-        if let Some(e) = Self::take_exception() {
-            Err(crate::error::Error::Exception(e).into())
-        } else {
-            Ok(())
-        }
+        let Some(mut obj) = Self::take_exception() else {
+            return Ok(());
+        };
+
+        let class = class_name_or_fallback(&obj);
+        let mut zv = Zval::new();
+        zv.set_object(&mut obj);
+        Err(PhpException::from_message(class).with_object(zv))
     }
 
     /// Request an interrupt of the PHP VM. This will call the registered
@@ -242,6 +281,10 @@ impl CompilerGlobals {
     /// # Panics
     ///
     /// * If static executor globals are not set
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine declares these globals statically, so the pointer is valid for the life of the process"
+    )]
     pub fn get() -> GlobalReadGuard<Self> {
         // SAFETY: PHP compiler globals are statically declared therefore should never
         // return an invalid pointer.
@@ -270,6 +313,10 @@ impl CompilerGlobals {
     /// # Panics
     ///
     /// * If static compiler globals are not set
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine declares these globals statically, so the pointer is valid for the life of the process"
+    )]
     pub fn get_mut() -> GlobalWriteGuard<Self> {
         // SAFETY: PHP compiler globals are statically declared therefore should never
         // return an invalid pointer.
@@ -303,6 +350,10 @@ impl SapiModule {
     /// # Panics
     ///
     /// * If static executor globals are not set
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine declares these globals statically, so the pointer is valid for the life of the process"
+    )]
     pub fn get() -> GlobalReadGuard<Self> {
         // SAFETY: PHP executor globals are statically declared therefore should never
         // return an invalid pointer.
@@ -323,6 +374,10 @@ impl SapiModule {
     /// # Panics
     ///
     /// * If static executor globals are not set
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine declares these globals statically, so the pointer is valid for the life of the process"
+    )]
     pub fn get_mut() -> GlobalWriteGuard<Self> {
         // SAFETY: PHP executor globals are statically declared therefore should never
         // return an invalid pointer.
@@ -778,6 +833,10 @@ impl FileGlobals {
     /// # Panics
     ///
     /// * If static file globals are not set
+    #[expect(
+        clippy::expect_used,
+        reason = "the engine declares these globals statically, so the pointer is valid for the life of the process"
+    )]
     pub fn get() -> GlobalReadGuard<Self> {
         // SAFETY: PHP executor globals are statically declared therefore should never
         // return an invalid pointer.

--- a/src/zend/handlers.rs
+++ b/src/zend/handlers.rs
@@ -47,6 +47,10 @@ impl ZendObjectHandlers {
     /// # Panics
     ///
     /// * If the offset of the `T` type is not a valid `i32` value.
+    #[expect(
+        clippy::expect_used,
+        reason = "the property offset is computed from a struct layout and fits in the engine's offset type"
+    )]
     pub unsafe fn init<T: RegisteredClass>(ptr: *mut ZendObjectHandlers) {
         unsafe { ptr::copy_nonoverlapping(&raw const std_object_handlers, ptr, 1) };
         let offset = ZendClassObject::<T>::std_offset();
@@ -112,6 +116,10 @@ impl ZendObjectHandlers {
         unsafe { zend_object_std_dtor(object) };
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "the formatted message is built from a class name and contains no NUL byte"
+    )]
     unsafe extern "C" fn clone_obj<T: RegisteredClass>(object: *mut ZendObject) -> *mut ZendObject {
         // PHP will call OBJ_RELEASE on the returned pointer if an exception
         // is thrown, so we must NEVER return the original object. Always

--- a/src/zend/streams.rs
+++ b/src/zend/streams.rs
@@ -86,15 +86,12 @@ impl StreamWrapper {
     ///
     /// * `Error::StreamWrapperRegistrationFailure` - If the stream wrapper
     ///   could not be registered
-    ///
-    /// # Panics
-    ///
-    /// * If the name cannot be converted to a C string
+    /// * `Error::InvalidCString` - If the name contains a NUL byte
     pub fn register(self, name: &str) -> Result<Self, Error> {
+        let name = std::ffi::CString::new(name)?;
         // We have to convert it to a static so owned streamwrapper doesn't get dropped.
         let copy = Box::new(self);
         let copy = Box::leak(copy);
-        let name = std::ffi::CString::new(name).expect("Could not create C string for name!");
         let result = unsafe { php_register_url_stream_wrapper(name.as_ptr(), copy) };
         if result == 0 {
             Ok(*copy)
@@ -129,12 +126,9 @@ impl StreamWrapper {
     ///
     /// * `Error::StreamWrapperUnregistrationFailure` - If the stream wrapper
     ///   could not be unregistered
-    ///
-    /// # Panics
-    ///
-    /// * If the name cannot be converted to a C string
+    /// * `Error::InvalidCString` - If the name contains a NUL byte
     pub fn unregister(name: &str) -> Result<(), Error> {
-        let name = std::ffi::CString::new(name).expect("Could not create C string for name!");
+        let name = std::ffi::CString::new(name)?;
         match unsafe { php_unregister_url_stream_wrapper(name.as_ptr()) } {
             0 => Ok(()),
             _ => Err(Error::StreamWrapperUnregistrationFailure),
@@ -172,3 +166,17 @@ pub type Stream = php_stream;
 
 /// Operations that can be performed with a stream wrapper
 pub type StreamWrapperOps = php_stream_wrapper_ops;
+
+#[cfg(feature = "embed")]
+#[cfg(test)]
+mod tests {
+    use super::StreamWrapper;
+    use crate::error::Error;
+
+    #[test]
+    fn unregister_rejects_a_name_with_a_nul_byte() {
+        let err = StreamWrapper::unregister("we\0ird");
+
+        assert!(matches!(err, Err(Error::InvalidCString { position: 2 })));
+    }
+}

--- a/src/zend/try_catch.rs
+++ b/src/zend/try_catch.rs
@@ -5,9 +5,17 @@ use std::ffi::c_void;
 use std::panic::{UnwindSafe, catch_unwind, resume_unwind};
 use std::ptr::null_mut;
 
-/// Error returned when a bailout occurs
-#[derive(Debug)]
-pub struct CatchError;
+/// Error returned when the engine did not run the closure to completion.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CatchError {
+    /// The engine bailed out, unwinding past the closure.
+    #[error("the engine bailed out")]
+    Bailout,
+    /// The closure result was never written back.
+    #[error("the closure result pointer was null")]
+    NullPanicPtr,
+}
 
 pub(crate) unsafe extern "C" fn panic_wrapper<R, F: FnOnce() -> R + UnwindSafe>(
     ctx: *const c_void,
@@ -84,9 +92,12 @@ fn do_try_catch<R, F: FnOnce() -> R + UnwindSafe>(func: F, first: bool) -> Resul
 
     let panic = panic_ptr.cast::<std::thread::Result<R>>();
 
-    // can be null if there is a bailout
-    if panic.is_null() || has_bailout {
-        return Err(CatchError);
+    if has_bailout {
+        return Err(CatchError::Bailout);
+    }
+
+    if panic.is_null() {
+        return Err(CatchError::NullPanicPtr);
     }
 
     match unsafe { *Box::from_raw(panic.cast::<std::thread::Result<R>>()) } {

--- a/src/zend/zend_extension.rs
+++ b/src/zend/zend_extension.rs
@@ -185,6 +185,10 @@ impl<'a> ZendExtensionBuilder<'a> {
     ///
     /// Panics if a `ZendExtensionHandler` has already been registered on this
     /// module. Each extension may register at most one handler.
+    #[expect(
+        clippy::expect_used,
+        reason = "the module is only absent on the test-only constructor"
+    )]
     pub fn finish(self) -> crate::builders::ModuleBuilder<'a> {
         register_config(ZendExtensionConfig {
             factory: self.factory,
@@ -331,6 +335,10 @@ unsafe extern "C" fn ext_deactivate() {
 /// # Safety
 ///
 /// Must be called during MINIT phase only.
+#[expect(
+    clippy::expect_used,
+    reason = "the name and version come from the module builder, i.e. from Cargo metadata compiled into the extension"
+)]
 pub(crate) unsafe fn zend_extension_startup(name: &str, version: &str) {
     let Some(cfg) = ZEND_EXT_CONFIG.get() else {
         return;

--- a/tests/src/integration/array/array.php
+++ b/tests/src/integration/array/array.php
@@ -161,3 +161,11 @@ assert($list[1] === 2, 'get_index_mut should leave other indexes alone');
 
 $empty_list = [];
 assert(test_array_get_index_mut($empty_list) === 0, 'get_index_mut should tolerate an empty array');
+
+$fruits = ['apple' => 'green', 'banana' => 'yellow'];
+assert('green' === test_array_remove($fruits, 'apple'));
+assert(null === test_array_remove($fruits, 'missing'));
+
+$colours = ['red', 'green'];
+assert('red' === test_array_remove_index($colours, 0));
+assert(null === test_array_remove_index($colours, 9));

--- a/tests/src/integration/array/mod.rs
+++ b/tests/src/integration/array/mod.rs
@@ -122,9 +122,21 @@ pub fn test_array_get_index_mut(arr: &mut ZendHashTable) -> i64 {
     i64::try_from(arr.len()).unwrap_or(i64::MAX)
 }
 
+#[php_function]
+pub fn test_array_remove(a: &mut ZendHashTable, key: String) -> Option<Zval> {
+    a.remove(key.as_str())
+}
+
+#[php_function]
+pub fn test_array_remove_index(a: &mut ZendHashTable, index: i64) -> Option<Zval> {
+    a.remove_index(index)
+}
+
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
     builder
         .function(wrap_function!(test_array))
+        .function(wrap_function!(test_array_remove))
+        .function(wrap_function!(test_array_remove_index))
         .function(wrap_function!(test_array_assoc))
         .function(wrap_function!(test_array_assoc_array_keys))
         .function(wrap_function!(test_btree_map))

--- a/tests/src/integration/enum_/enum.php
+++ b/tests/src/integration/enum_/enum.php
@@ -18,3 +18,12 @@ assert(StringBackedEnum::tryFrom('foo') === StringBackedEnum::Variant1);
 assert(StringBackedEnum::tryFrom('baz') === null);
 
 assert(test_enum(TestEnum::Variant1) === StringBackedEnum::Variant2);
+
+assert(test_enum_from_name('Variant1') === StringBackedEnum::Variant1);
+
+try {
+    test_enum_from_name('Nope');
+    assert(false, 'an unknown case should have failed');
+} catch (\Throwable $e) {
+    assert('enum has no case matching `Nope`' === $e->getMessage(), $e->getMessage());
+}

--- a/tests/src/integration/enum_/mod.rs
+++ b/tests/src/integration/enum_/mod.rs
@@ -1,4 +1,11 @@
-use ext_php_rs::{error::Result, php_enum, php_function, prelude::ModuleBuilder, wrap_function};
+use ext_php_rs::{
+    enum_::RegisteredEnum,
+    error::Result,
+    exception::PhpException,
+    php_enum, php_function,
+    prelude::{ModuleBuilder, PhpResult},
+    wrap_function,
+};
 
 #[php_enum]
 #[php(allow_native_discriminants)]
@@ -38,12 +45,18 @@ pub fn test_enum(a: TestEnum) -> Result<StringBackedEnum> {
     }
 }
 
+#[php_function]
+pub fn test_enum_from_name(name: String) -> PhpResult<StringBackedEnum> {
+    StringBackedEnum::from_name(&name).map_err(PhpException::from)
+}
+
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
     builder
         .enumeration::<TestEnum>()
         .enumeration::<IntBackedEnum>()
         .enumeration::<StringBackedEnum>()
         .function(wrap_function!(test_enum))
+        .function(wrap_function!(test_enum_from_name))
 }
 
 #[cfg(test)]

--- a/tests/src/integration/exception/exception.php
+++ b/tests/src/integration/exception/exception.php
@@ -11,3 +11,35 @@ try {
     assert($e instanceof \Test\TestException);
     assert('Not good custom!' === $e->getMessage());
 }
+
+try {
+    call_throwing_callable(function () {
+        throw new \LogicException('boom');
+    });
+    assert(false, 'the original exception should have propagated');
+} catch (\Throwable $e) {
+    assert($e instanceof \LogicException, get_class($e));
+    assert('boom' === $e->getMessage(), $e->getMessage());
+    assert(__FILE__ === $e->getFile(), $e->getFile());
+    assert(
+        '{closure}' === $e->getTrace()[0]['function'] || str_contains($e->getTrace()[0]['function'], 'closure'),
+        $e->getTrace()[0]['function']
+    );
+}
+
+try {
+    throw_over_pending_exception(function () {
+        throw new \RangeException('first');
+    });
+    assert(false, 'the pending exception should have propagated');
+} catch (\Throwable $e) {
+    assert($e instanceof \RangeException, get_class($e));
+    assert('first' === $e->getMessage(), $e->getMessage());
+}
+
+try {
+    throw_non_object();
+    assert(false, 'throwing a non-object should have failed');
+} catch (\Throwable $e) {
+    assert('an object was expected' === $e->getMessage(), $e->getMessage());
+}

--- a/tests/src/integration/exception/mod.rs
+++ b/tests/src/integration/exception/mod.rs
@@ -1,4 +1,8 @@
-use ext_php_rs::{prelude::*, zend::ce};
+use ext_php_rs::{
+    prelude::*,
+    types::{ZendCallable, Zval},
+    zend::ce,
+};
 
 #[php_class]
 #[php(name = "Test\\TestException")]
@@ -15,7 +19,29 @@ pub fn throw_custom_exception() -> PhpResult<i32> {
 
 #[php_function]
 pub fn throw_default_exception() -> PhpResult<i32> {
-    Err(PhpException::default("Not good!".into()))
+    Err(PhpException::from_message("Not good!".into()))
+}
+
+#[php_function]
+pub fn call_throwing_callable(call: ZendCallable) -> PhpResult<()> {
+    call.try_call(vec![])?;
+
+    Ok(())
+}
+
+#[php_function]
+pub fn throw_over_pending_exception(call: ZendCallable) -> PhpResult<()> {
+    let _ = call.try_call(vec![]);
+    PhpException::from_message("second".into()).throw()?;
+
+    Ok(())
+}
+
+#[php_function]
+pub fn throw_non_object() -> PhpResult<()> {
+    ext_php_rs::exception::throw_object(Zval::new())?;
+
+    Ok(())
 }
 
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
@@ -23,6 +49,9 @@ pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
         .class::<TestException>()
         .function(wrap_function!(throw_default_exception))
         .function(wrap_function!(throw_custom_exception))
+        .function(wrap_function!(call_throwing_callable))
+        .function(wrap_function!(throw_over_pending_exception))
+        .function(wrap_function!(throw_non_object))
 }
 
 #[cfg(test)]

--- a/tests/src/integration/object/mod.rs
+++ b/tests/src/integration/object/mod.rs
@@ -10,10 +10,16 @@ pub fn test_object_to_string(a: &mut ZendObject) -> PhpResult<String> {
     a.extract::<String>().map_err(PhpException::from)
 }
 
+#[php_function]
+pub fn test_object_read_property(a: &ZendObject, name: String) -> PhpResult<String> {
+    a.get_property::<String>(&name).map_err(PhpException::from)
+}
+
 pub fn build_module(builder: ModuleBuilder) -> ModuleBuilder {
     builder
         .function(wrap_function!(test_object))
         .function(wrap_function!(test_object_to_string))
+        .function(wrap_function!(test_object_read_property))
 }
 
 #[cfg(test)]

--- a/tests/src/integration/object/object.php
+++ b/tests/src/integration/object/object.php
@@ -16,3 +16,12 @@ assert($test->string === 'string');
 assert($test->bool === true);
 assert($test->number === 2022);
 assert($test->array === [1, 2, 3]);
+
+assert('string' === test_object_read_property($obj, 'string'));
+
+try {
+    test_object_read_property($obj, 'missing');
+    assert(false, 'reading a missing property should have failed');
+} catch (\Throwable $e) {
+    assert('property `missing` does not exist on the object' === $e->getMessage(), $e->getMessage());
+}


### PR DESCRIPTION
## Description

`Error` no longer carries engine memory, so the crate-wide `Result` is finally `Send + Sync` and usable with threads and `anyhow`: a thrown PHP exception stays in the executor globals and surfaces as `ExceptionPending { class }`, which is what keeps its class and stack trace intact all the way back to PHP. The rest of the family follows suit, with `thiserror` on every error type, real context on the variants, `CatchError` and `EmbedError` finally printable, and `clippy::expect_used` denied outside tests.

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have added tests that prove my code works as expected.
- [x] I have added documentation if applicable.
- [x] I have added a [migration guide](CONTRIBUTING.md#breaking-changes) if applicable.